### PR TITLE
Add cargo build targets to pick up dev-dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod recipe;
 mod skeleton;
 
-pub use recipe::{DefaultFeatures, OptimisationProfile, Recipe};
+pub use recipe::{DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
 pub use skeleton::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,16 +71,17 @@ pub struct Cook {
     /// Space or comma separated list of features to activate.
     #[clap(long, use_delimiter = true, value_delimiter = ",")]
     features: Option<Vec<String>>,
-    /// Build benchmarks
+    /// Build all benches
     #[clap(long)]
     benches: bool,
-    /// Build tests
+    /// Build all tests
     #[clap(long)]
     tests: bool,
-    /// Build examples
+    /// Build all examples
     #[clap(long)]
     examples: bool,
-    /// Build all targets
+    /// Build all targets.
+    /// This is equivalent to specifying `--tests --benches --examples`.
     #[clap(long)]
     all_targets: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use chef::{DefaultFeatures, OptimisationProfile, Recipe};
+use chef::{DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
 use clap::Clap;
 use fs_err as fs;
 use std::collections::HashSet;
@@ -71,6 +71,18 @@ pub struct Cook {
     /// Space or comma separated list of features to activate.
     #[clap(long, use_delimiter = true, value_delimiter = ",")]
     features: Option<Vec<String>>,
+    /// Build benchmarks
+    #[clap(long)]
+    benches: bool,
+    /// Build tests
+    #[clap(long)]
+    tests: bool,
+    /// Build examples
+    #[clap(long)]
+    examples: bool,
+    /// Build all targets
+    #[clap(long)]
+    all_targets: bool,
 }
 
 fn _main() -> Result<(), anyhow::Error> {
@@ -90,6 +102,10 @@ fn _main() -> Result<(), anyhow::Error> {
             no_default_features,
             features,
             target_dir,
+            benches,
+            tests,
+            examples,
+            all_targets,
         }) => {
             let features: Option<HashSet<String>> = features.and_then(|features| {
                 if features.is_empty() {
@@ -115,8 +131,21 @@ fn _main() -> Result<(), anyhow::Error> {
                 .context("Failed to read recipe from the specified path.")?;
             let recipe: Recipe =
                 serde_json::from_str(&serialized).context("Failed to deserialize recipe.")?;
+            let target_args = TargetArgs {
+                benches,
+                tests,
+                examples,
+                all_targets,
+            };
             recipe
-                .cook(profile, default_features, features, target, target_dir)
+                .cook(
+                    profile,
+                    default_features,
+                    features,
+                    target,
+                    target_dir,
+                    target_args,
+                )
                 .context("Failed to cook recipe.")?;
         }
         Command::Prepare(Prepare { recipe_path }) => {

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -144,6 +144,36 @@ impl Skeleton {
                 fs::write(bench_path, "fn main() {}")?;
             }
 
+            // Create dummy entrypoint files for for all tests
+            for test in &parsed_manifest.test.unwrap_or_default() {
+                // Relative to the manifest path
+                let test_name = test.name.as_ref().context("Missing test name.")?;
+                let test_relative_path = test
+                    .path
+                    .clone()
+                    .unwrap_or_else(|| format!("tests/{}.rs", test_name));
+                let test_path = parent_directory.join(test_relative_path);
+                if let Some(parent_directory) = test_path.parent() {
+                    fs::create_dir_all(parent_directory)?;
+                }
+                fs::write(test_path, "fn main() {}")?;
+            }
+
+            // Create dummy entrypoint files for for all examples
+            for example in &parsed_manifest.example.unwrap_or_default() {
+                // Relative to the manifest path
+                let example_name = example.name.as_ref().context("Missing example name.")?;
+                let example_relative_path = example
+                    .path
+                    .clone()
+                    .unwrap_or_else(|| format!("examples/{}.rs", example_name));
+                let example_path = parent_directory.join(example_relative_path);
+                if let Some(parent_directory) = example_path.parent() {
+                    fs::create_dir_all(parent_directory)?;
+                }
+                fs::write(example_path, "fn main() {}")?;
+            }
+
             // Create dummy build script file if specified
             if let Some(package) = parsed_manifest.package {
                 if let Some(build) = package.build {

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -156,7 +156,7 @@ impl Skeleton {
                 if let Some(parent_directory) = test_path.parent() {
                     fs::create_dir_all(parent_directory)?;
                 }
-                fs::write(test_path, "fn main() {}")?;
+                fs::write(test_path, "")?;
             }
 
             // Create dummy entrypoint files for for all examples

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -182,3 +182,97 @@ harness = false
         .path()
         .exists())
 }
+
+#[test]
+pub fn tests() {
+    // Arrange
+    let content = r#"
+[package]
+name = "test-dummy"
+version = "0.1.0"
+edition = "2018"
+
+[[test]]
+name = "foo"
+    "#;
+
+    let recipe_directory = TempDir::new().unwrap();
+    let manifest = recipe_directory.child("Cargo.toml");
+    manifest.write_str(content).unwrap();
+    recipe_directory.child("src").create_dir_all().unwrap();
+    recipe_directory
+        .child("src")
+        .child("lib.rs")
+        .touch()
+        .unwrap();
+    recipe_directory.child("tests").create_dir_all().unwrap();
+    recipe_directory
+        .child("tests")
+        .child("foo.rs")
+        .touch()
+        .unwrap();
+
+    // Act
+    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let cook_directory = TempDir::new().unwrap();
+    skeleton
+        .build_minimum_project(cook_directory.path())
+        .unwrap();
+
+    // Assert
+    assert_eq!(1, skeleton.manifests.len());
+    let manifest = skeleton.manifests[0].clone();
+    assert_eq!("Cargo.toml", manifest.relative_path.to_str().unwrap());
+    assert!(cook_directory
+        .child("tests")
+        .child("foo.rs")
+        .path()
+        .exists())
+}
+
+#[test]
+pub fn examples() {
+    // Arrange
+    let content = r#"
+[package]
+name = "test-dummy"
+version = "0.1.0"
+edition = "2018"
+
+[[example]]
+name = "foo"
+    "#;
+
+    let recipe_directory = TempDir::new().unwrap();
+    let manifest = recipe_directory.child("Cargo.toml");
+    manifest.write_str(content).unwrap();
+    recipe_directory.child("src").create_dir_all().unwrap();
+    recipe_directory
+        .child("src")
+        .child("lib.rs")
+        .touch()
+        .unwrap();
+    recipe_directory.child("examples").create_dir_all().unwrap();
+    recipe_directory
+        .child("examples")
+        .child("foo.rs")
+        .touch()
+        .unwrap();
+
+    // Act
+    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let cook_directory = TempDir::new().unwrap();
+    skeleton
+        .build_minimum_project(cook_directory.path())
+        .unwrap();
+
+    // Assert
+    assert_eq!(1, skeleton.manifests.len());
+    let manifest = skeleton.manifests[0].clone();
+    assert_eq!("Cargo.toml", manifest.relative_path.to_str().unwrap());
+    assert!(cook_directory
+        .child("examples")
+        .child("foo.rs")
+        .path()
+        .exists())
+}


### PR DESCRIPTION
Hi there, big fan of this project 😄 thought I'd share a change that has helped me out - building multiple targets, which picks up `dev-dependencies`. Happy to discuss further!

## Changes
1. Add some flags to `cargo chef cook`, which are passed directly to `cargo build`:
    1. `--benches`
    2. `--tests`
    3. `--examples`
    4. `--all-targets`
2. Add skeleton files for `tests` and `examples` in the same fashion as already happens for `benches`.

## Motivating Example
In the build-test-release cycle, building and testing rust code often shares some (but not all) cacheable dependencies. With this change you can pre-compile both your production and your test dependencies, speeding up both, like so:
```dockerfile
FROM rust AS menu-planner
WORKDIR /app
COPY . /app/
RUN ["cargo", "chef", "prepare"]

FROM rust AS kitchen
WORKDIR /app
COPY --from=menu-planner /app/recipe.json /app/recipe.json
RUN ["cargo", "chef", "cook", "--release", "--all-targets"]

FROM rust AS builder
WORKDIR /app
COPY . /app/
COPY --from=kitchen /app/target /app/target
RUN ["cargo", "build", "--release", "--all-targets"]

FROM rust AS testtime
WORKDIR /app
COPY . /app/
COPY --from=builder /app/target /app/target
CMD ["cargo", "test", "--release"]

FROM rust AS runtime
COPY --from=builder /app/target/release/cachetest cachetest
CMD ["./cachetest"]
```
Then you can run `docker build . -t tester --target=testtime` to make full use of the cached dependencies.