### PR TITLE
Replace parsed build args with positional args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod recipe;
 mod skeleton;
 
-pub use recipe::{DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
+pub use recipe::{OptimisationProfile, Recipe};
 pub use skeleton::*;

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,20 +1,12 @@
 use crate::Skeleton;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Recipe {
     pub skeleton: Skeleton,
-}
-
-pub struct TargetArgs {
-    pub benches: bool,
-    pub tests: bool,
-    pub examples: bool,
-    pub all_targets: bool,
 }
 
 impl Recipe {
@@ -26,22 +18,13 @@ impl Recipe {
     pub fn cook(
         &self,
         profile: OptimisationProfile,
-        default_features: DefaultFeatures,
-        features: Option<HashSet<String>>,
         target: Option<String>,
         target_dir: Option<PathBuf>,
-        target_args: TargetArgs,
+        args: &Vec<String>,
     ) -> Result<(), anyhow::Error> {
         let current_directory = std::env::current_dir()?;
         self.skeleton.build_minimum_project(&current_directory)?;
-        build_dependencies(
-            profile,
-            default_features,
-            features,
-            &target,
-            &target_dir,
-            target_args,
-        );
+        build_dependencies(args);
         self.skeleton
             .remove_compiled_dummy_libraries(current_directory, profile, target, target_dir)
             .context("Failed to clean up dummy compilation artifacts.")?;
@@ -55,50 +38,10 @@ pub enum OptimisationProfile {
     Debug,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum DefaultFeatures {
-    Enabled,
-    Disabled,
-}
-
-fn build_dependencies(
-    profile: OptimisationProfile,
-    default_features: DefaultFeatures,
-    features: Option<HashSet<String>>,
-    target: &Option<String>,
-    target_dir: &Option<PathBuf>,
-    target_args: TargetArgs,
-) {
+fn build_dependencies(args: &Vec<String>) {
     let mut command = Command::new("cargo");
     let command_with_args = command.arg("build");
-    if profile == OptimisationProfile::Release {
-        command_with_args.arg("--release");
-    }
-    if default_features == DefaultFeatures::Disabled {
-        command_with_args.arg("--no-default-features");
-    }
-    if let Some(features) = features {
-        let feature_flag = features.into_iter().collect::<Vec<_>>().join(",");
-        command_with_args.arg("--features").arg(feature_flag);
-    }
-    if let Some(target) = target {
-        command_with_args.arg("--target").arg(target);
-    }
-    if let Some(target_dir) = target_dir {
-        command_with_args.arg("--target-dir").arg(target_dir);
-    }
-    if target_args.benches {
-        command_with_args.arg("--benches");
-    }
-    if target_args.tests {
-        command_with_args.arg("--tests");
-    }
-    if target_args.examples {
-        command_with_args.arg("--examples");
-    }
-    if target_args.all_targets {
-        command_with_args.arg("--all-targets");
-    }
+    command_with_args.args(args);
 
     execute_command(command_with_args);
 }


### PR DESCRIPTION
This removes manual parsing of all `cargo-build` arguments. Instead, build arguments are now accepted through last positional arguments. Those arguments which are important for decisions made by `cargo-chef` are parsed from there.

This allows specifying all possible build arguments while still reacting to some of them. Originally, I was trying to pass `--workspace`, which is not possible currently, but found that it might be easier to just allow specifying any build argument instead of parsing each possible build argument explicitly.

What do you think?