### PR TITLE
Update Readme with more efficient planning stage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ FROM rust as planner
 WORKDIR app
 # We only pay the installation cost once, 
 # it will be cached from the second build onwards
-RUN cargo install cargo-chef 
-COPY . .
+RUN cargo install cargo-chef
+COPY Cargo.toml Cargo.lock /app/
 RUN cargo chef prepare  --recipe-path recipe.json
 
 FROM rust as cacher


### PR DESCRIPTION
Hi,
I just started my first experiments with cargo-chef (as described in the readme) and noticed, that all my dependencies were rebuild when I changed my code.
In the Readme  the prepare stage is displayed like this:

```dockerfile
FROM rust as planner
WORKDIR app

RUN cargo install cargo-chef 
COPY . .
RUN cargo chef prepare  --recipe-path recipe.json
``` 
This means that the prepare stage depends on all files in the current directory. When we change this to:
```dockerfile
FROM rust as planner
WORKDIR app

RUN cargo install cargo-chef 
COPY Cargo.toml Cargo.lock /app/ # <-- this is different
RUN cargo chef prepare  --recipe-path recipe.json
``` 
This is no longer the case and it worked for my project. Unfortunately, I am not clear enough on the internals of cargo-chef and if this works for every project. If so I would propose to merge this pull request, otherwise feel free to close it :).

BTW: Thank you very much for this awesome tool!

Best regards,
Lesstat