### PR TITLE
Warning about file overwrite when stdout is a TTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "atty",
  "cargo-manifest",
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ name = "chef"
 path = "src/lib.rs"
 
 [dependencies]
+atty = "0.2.14"
 clap = "3.0.0-beta.2"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ cargo install cargo-chef
 
 ## How to use
 
+> :warning:  **cargo-chef is not meant to be run locally**  
+> Its primary use-case is to speed up container builds by running BEFORE
+> the actual source code is copied over. Don't run it on existing codebases to avoid
+> having files being overwritten.
+
 `cargo-chef` exposes two commands: `prepare` and `cook`:
 
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,14 +110,18 @@ fn _main() -> Result<(), anyhow::Error> {
         }) => {
             if atty::is(atty::Stream::Stdout) {
                 eprintln!("WARNING stdout appears to be a terminal.");
-                eprintln!("cargo-chef is not meant to be run in an interactive environment \
+                eprintln!(
+                    "cargo-chef is not meant to be run in an interactive environment \
                 and will overwrite some existing files (namely any `lib.rs`, `main.rs` and \
-                `Cargo.toml` it finds).");
+                `Cargo.toml` it finds)."
+                );
                 eprintln!();
                 eprint!("To continue anyway, type `yes`: ");
 
                 let mut answer = String::with_capacity(3);
-                std::io::stdin().read_line(&mut answer).context("Failed to read from stdin")?;
+                std::io::stdin()
+                    .read_line(&mut answer)
+                    .context("Failed to read from stdin")?;
 
                 if "yes" != answer.trim() {
                     std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,22 @@ fn _main() -> Result<(), anyhow::Error> {
             examples,
             all_targets,
         }) => {
+            if atty::is(atty::Stream::Stdout) {
+                eprintln!("WARNING stdout appears to be a terminal.");
+                eprintln!("cargo-chef is not meant to be run in an interactive environment \
+                and will overwrite some existing files (namely any `lib.rs`, `main.rs` and \
+                `Cargo.toml` it finds).");
+                eprintln!();
+                eprint!("To continue anyway, type `yes`: ");
+
+                let mut answer = String::with_capacity(3);
+                std::io::stdin().read_line(&mut answer).context("Failed to read from stdin")?;
+
+                if "yes" != answer.trim() {
+                    std::process::exit(1);
+                }
+            }
+
             let features: Option<HashSet<String>> = features.and_then(|features| {
                 if features.is_empty() {
                     None


### PR DESCRIPTION
This PR addresses #27 and #31 by introducing a warning and interactive prompt when stdout is detected as being a TTY.

This should avoid surprise and actual source files being overwritten by the skeleton when running `cook` outside of container builds