### PR TITLE
make recipe construction deterministic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ env_logger = "0.8.1"
 globwalk = "0.8.0"
 anyhow = "1.0.33"
 pathdiff = "0.2.0"
-cargo-manifest = "0.2.1"
+cargo-manifest = "0.2.2"
 fs-err = "2.5.0"
-toml = "0.5.7"
+toml = { version = "0.5.7", features = ["preserve_order"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/tests/recipe.rs
+++ b/tests/recipe.rs
@@ -1,0 +1,60 @@
+use assert_fs::prelude::{FileTouch, FileWriteStr, PathChild, PathCreateDir};
+use assert_fs::TempDir;
+use chef::Recipe;
+
+fn quick_recipe(content: &str) -> Recipe {
+    let recipe_directory = TempDir::new().unwrap();
+    let manifest = recipe_directory.child("Cargo.toml");
+    manifest.write_str(content).unwrap();
+    let bin_dir = recipe_directory.child("src").child("bin");
+    let test_dir = recipe_directory.child("tests");
+    bin_dir.create_dir_all().unwrap();
+    test_dir.create_dir_all().unwrap();
+    for filename in &["f.rs", "e.rs", "d.rs", "c.rs", "b.rs", "a.rs"] {
+        bin_dir.child(filename).touch().unwrap();
+        test_dir.child(filename).touch().unwrap();
+    }
+    Recipe::prepare(recipe_directory.path().into()).unwrap()
+}
+
+#[test]
+fn test_recipe_is_deterministic() {
+    let content = r#"
+[package]
+name = "test-dummy"
+version = "0.1.0"
+edition = "2018"
+
+[[bin]]
+name = "bin2"
+path = "some-path.rs"
+
+[[bin]]
+name = "bin1"
+path = "some-other-path.rs"
+
+[[test]]
+name = "test2"
+path = "some-other-path.rs"
+
+[[test]]
+name = "test1"
+path = "some-path.rs"
+"#;
+    let recipe = quick_recipe(content);
+    let recipe_json = serde_json::to_string(&recipe).unwrap();
+    // construct a recipe a bunch more times and assert that each time
+    // it is equal to the first (both the object and the json serialization)
+    for _ in 0..5 {
+        let recipe2 = quick_recipe(content);
+        let recipe2_json = serde_json::to_string(&recipe).unwrap();
+        assert_eq!(
+            recipe, recipe2,
+            "recipes of equal directories are not equal"
+        );
+        assert_eq!(
+            recipe_json, recipe2_json,
+            "recipe jsons of equal directories are not equal"
+        );
+    }
+}


### PR DESCRIPTION
Make receipe construction deterministic.

The actual fix is in the `cargo-manifest` crate https://github.com/LukeMathWalker/cargo-manifest/pull/5 (which needs to be merged before this will go green).

Here I have added what I hope to be a reasonably comprehensive regression test.

closes #36 