### PR TITLE
cook: clean up also dummy build.rs artifacts

### DIFF
--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -43,7 +43,7 @@ impl Recipe {
             target_args,
         );
         self.skeleton
-            .remove_compiled_dummy_libraries(current_directory, profile, target, target_dir)
+            .remove_compiled_dummies(current_directory, profile, target, target_dir)
             .context("Failed to clean up dummy compilation artifacts.")?;
         Ok(())
     }

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -219,7 +219,7 @@ impl Skeleton {
     /// workspace.
     /// Given the usage of dummy `lib.rs` files, keeping them around leads to funny compilation
     /// errors if they are a dependency of another project within the workspace.
-    pub fn remove_compiled_dummy_libraries<P: AsRef<Path>>(
+    pub fn remove_compiled_dummies<P: AsRef<Path>>(
         &self,
         base_path: P,
         profile: OptimisationProfile,

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -241,13 +241,10 @@ impl Skeleton {
         for manifest in &self.manifests {
             let parsed_manifest =
                 cargo_manifest::Manifest::from_slice(manifest.contents.as_bytes())?;
+            let package = parsed_manifest.package.as_ref().unwrap();
 
             for lib in &parsed_manifest.lib {
-                let library_name = lib
-                    .name
-                    .clone()
-                    .unwrap_or_else(|| parsed_manifest.package.as_ref().unwrap().name.to_owned())
-                    .replace("-", "_");
+                let library_name = lib.name.as_ref().unwrap_or(&package.name).replace("-", "_");
                 let walker =
                     GlobWalkerBuilder::new(&target_directory, format!("/**/lib{}*", library_name))
                         .build()?;


### PR DESCRIPTION
Should fix #42.

Fixes a build of an example project https://github.com/strohel/cargo-chef-build-rs for me.

We only needed to remove the case 1. b). That makes sense, because fingerprints only check what is in `build/`, and run of the build script has a dependency on its build.

Note that there is special case, which currently builds, but is not fully cached: when there is a `build.rs` file on filesystem, but no mention of `build = "build.rs"` in Cargo.toml. This one is separate though. It's proper fix would be to extend `cargo-manifest` to also autodetect `build` property in its `Manifest::complete_from_abstract_filesystem()` method (in addition to bins, libs, ...).