### PR TITLE
Add docker GitHub Actions workflow to build docker images 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Build Docker images
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/docker.yml'
+      - 'docker/**'
+  schedule:
+    - cron: '42 7 * * *' # run at 7:42 UTC (morning) every day
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+    env:
+      RUST_IMAGE_TAG: latest
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_TOKEN
+
+          RUST_IMAGE=rust:$RUST_IMAGE_TAG
+          RUST_VERSION=$(docker run --rm $RUST_IMAGE rustc --version)
+          echo "Rust version in $RUST_IMAGE is $RUST_VERSION."
+
+          CHEF_IMAGE=$DOCKERHUB_USERNAME/cargo-chef:$RUST_IMAGE_TAG
+          CHEF_RUST_VERSION=$(docker run --rm $CHEF_IMAGE rustc --version || echo "none")
+          echo "Rust version in $CHEF_IMAGE is $CHEF_RUST_VERSION."
+          CHEF_VERSION=$(docker run --rm $CHEF_IMAGE cargo install --list | grep "^cargo-chef v" | cut -d v -f 2 | cut -d : -f 1 || echo "none")
+          echo "cargo chef version in $CHEF_IMAGE is $CHEF_VERSION."
+
+          # Somewhat tricky way to determine latest version without installing anything
+          LATEST_CHEF=$(cargo search --limit 1 cargo-chef | head -n 1 | cut -d '"' -f 2)
+          echo "Latest cargo chef version on crates.io is $LATEST_CHEF."
+
+          if [ "$RUST_VERSION" == "$CHEF_RUST_VERSION" -a "$LATEST_CHEF" == "$CHEF_VERSION" ]; then
+            echo "All versions up-to-date, existing early."
+            exit 0
+          fi
+
+          docker build docker/ -t $CHEF_IMAGE --build-arg=BASE_IMAGE=$RUST_IMAGE
+          docker push $CHEF_IMAGE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE=rust
+FROM $BASE_IMAGE
+
+RUN cargo install cargo-chef && rm -rf $CARGO_HOME/registry/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,5 @@
+This directory contains Dockefile to build cargo-chef image that can be used as
+a base layer for `planner` and `cacher` build stages.
+
+Note that this builds `carcho chef` from latest release on crates.io - not from
+the current repository.


### PR DESCRIPTION
Currently uses just the "latest" tag of the upstream rust base image, but the
approach is extensible to many such tags.

Requires following GitHub repository secrets to be defined:

DOCKERHUB_USERNAME - username on https://hub.docker.com/
DOCKERHUB_TOKEN - token from Docker Hub for DOCKERHUB_USERNAME used to push images.

The job is scheduled to run every night, exiting early if current images are
up-to-date.

Seems to work fine:
- built image: https://hub.docker.com/r/strohel/cargo-chef
- GitHub job that built the image: https://github.com/strohel/cargo-chef/runs/1735587797
- GitHub job that was no-op because versions were up-to-date: https://github.com/strohel/cargo-chef/runs/1735685360

Fixes #41.