### PR TITLE
Add dummy main function if test harness is disabled

### DIFF
--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -179,7 +179,11 @@ impl Skeleton {
                 if let Some(parent_directory) = test_path.parent() {
                     fs::create_dir_all(parent_directory)?;
                 }
-                fs::write(test_path, "")?;
+                if test.harness {
+                    fs::write(test_path, "")?;
+                } else {
+                    fs::write(test_path, "fn main() {}")?;
+                }
             }
 
             // Create dummy entrypoint files for for all examples


### PR DESCRIPTION
> Thanks for awesome work! 🥳

## Background

`main` function should be defined if harness is disabled as mentioned in [document](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-harness-field).

I think [cucumber-rust](https://github.com/bbqsrc/cucumber-rust/blob/main/Cargo.toml#L43-L45) is a good sample for this issue:

```sh
error[E0601]: `main` function not found in crate `cucumber_builder`
  |
  = note: consider adding a `main` function to `tests/cucumber_builder.rs`
```

## Changes

- Add dummy main function if test harness is disabled