### PR TITLE
Remove artifact directories for libraries/build scripts from the current workspace

### DIFF
--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -277,7 +277,11 @@ impl Skeleton {
                     .build()?;
                     for file in walker {
                         let file = file?;
-                        fs::remove_file(file.path())?;
+                        if file.file_type().is_file() {
+                            fs::remove_file(file.path())?;
+                        } else if file.file_type().is_dir() {
+                            fs::remove_dir_all(file.path())?;
+                        }
                     }
                 }
 


### PR DESCRIPTION
* For recent versions of rust, compilation may create directories which match
  the "/**/lib{}*" glob, so test the file type and remove these as well.