### PR TITLE
Remove old incorrect commit

### DIFF
--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -37,10 +37,6 @@ impl Skeleton {
                     // Required to detect bin/libs when the related section is omitted from the manifest
                     parsed.complete_from_path(&absolute_path)?;
 
-                    // Workaround :(
-                    // As suggested in issue #142 on toml-rs github repository
-                    // First convert the Config instance to a toml Value,
-                    // then serialize it to toml
                     let mut intermediate = toml::Value::try_from(parsed)?;
 
                     // Specifically, toml gives no guarantees to the ordering of the auto binaries


### PR DESCRIPTION
Issue #142 on toml-rs is already solved and is no longer the reason to parse to toml `Value`. 
The reason why this is needed is to sort the manifest.