### PR TITLE
Add support for --workspace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,9 @@ pub struct Cook {
     /// Package to build (see `cargo help pkgid`)
     #[clap(long, short = 'p')]
     package: Option<String>,
+    /// Build all members in the workspace.
+    #[clap(long)]
+    workspace: bool,
 }
 
 fn _main() -> Result<(), anyhow::Error> {
@@ -116,6 +119,7 @@ fn _main() -> Result<(), anyhow::Error> {
             all_targets,
             manifest_path,
             package,
+            workspace,
         }) => {
             if atty::is(atty::Stream::Stdout) {
                 eprintln!("WARNING stdout appears to be a terminal.");
@@ -177,6 +181,7 @@ fn _main() -> Result<(), anyhow::Error> {
                     target_args,
                     manifest_path,
                     package,
+                    workspace,
                 })
                 .context("Failed to cook recipe.")?;
         }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -26,6 +26,7 @@ pub struct CookArgs {
     pub target_args: TargetArgs,
     pub manifest_path: Option<PathBuf>,
     pub package: Option<String>,
+    pub workspace: bool,
 }
 
 impl Recipe {
@@ -72,6 +73,7 @@ fn build_dependencies(args: &CookArgs) {
         target_args,
         manifest_path,
         package,
+        workspace,
     } = args;
     let mut command = Command::new("cargo");
     let command_with_args = command.arg("build");
@@ -108,6 +110,9 @@ fn build_dependencies(args: &CookArgs) {
     }
     if let Some(package) = package {
         command_with_args.arg("--package").arg(package);
+    }
+    if *workspace {
+        command_with_args.arg("--workspace");
     }
 
     execute_command(command_with_args);


### PR DESCRIPTION
I would like to cook a whole workspace, but would prefer not to specify each member via `--package` manually.

This PR introduces the corresponding `--workspace` argument (superseding #28).

What do you think?