### PR TITLE
Included refresh instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ COPY --from=builder /app/target/release/app /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/app"]
 ```
 
+When your cacher becomes stale (you start seeing the builder stage rebuild everything), refresh the cacher by passing the `--no-cache` flag to `docker build`.
+
 ## Benefits vs Limitations
 
 `cargo-chef` has been tested on a few OpenSource projects and some of commercial projects, but our testing has definitely not exhausted the range of possibilities when it comes to `cargo build` customisations and we are sure that there are a few rough edges that will have to be smoothed out - please file issues on [GitHub](https://github.com/LukeMathWalker/cargo-chef).


### PR DESCRIPTION
Thank you so much for this tool! I use it to efficiently build the [Scryer Prolog Docker image](https://github.com/mthom/scryer-prolog/blob/master/Dockerfile). I was completely lost dealing with complicated dependencies before I found `cargo-chef `.

I added a sentence about refreshing the cacher to the README. Might save someone a head scratching moment and a search.