### PR TITLE
Add `--offline` option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,9 @@ pub struct Cook {
     /// Build all members in the workspace.
     #[clap(long)]
     workspace: bool,
+    /// Build offline.
+    #[clap(long)]
+    offline: bool,
 }
 
 fn _main() -> Result<(), anyhow::Error> {
@@ -120,6 +123,7 @@ fn _main() -> Result<(), anyhow::Error> {
             manifest_path,
             package,
             workspace,
+            offline,
         }) => {
             if atty::is(atty::Stream::Stdout) {
                 eprintln!("WARNING stdout appears to be a terminal.");
@@ -182,6 +186,7 @@ fn _main() -> Result<(), anyhow::Error> {
                     manifest_path,
                     package,
                     workspace,
+                    offline,
                 })
                 .context("Failed to cook recipe.")?;
         }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -27,6 +27,7 @@ pub struct CookArgs {
     pub manifest_path: Option<PathBuf>,
     pub package: Option<String>,
     pub workspace: bool,
+    pub offline: bool,
 }
 
 impl Recipe {
@@ -74,6 +75,7 @@ fn build_dependencies(args: &CookArgs) {
         manifest_path,
         package,
         workspace,
+        offline,
     } = args;
     let mut command = Command::new("cargo");
     let command_with_args = command.arg("build");
@@ -113,6 +115,9 @@ fn build_dependencies(args: &CookArgs) {
     }
     if *workspace {
         command_with_args.arg("--workspace");
+    }
+    if *offline {
+        command_with_args.arg("--offline");
     }
 
     execute_command(command_with_args);


### PR DESCRIPTION
to support building with vendored and patched dependencies. 

I typically run my build with
```
cargo build --offline -p <specific package name>
```
I tried translating my existing Dockerfile to use cargo chef,
but I was running into compilation errors where it wasn't
picking up the patched dependencies.

I commented out the portion of my Dockerfile
that ran `cook` and instead ran the above command.
This indeed works. So, I've added this option to the
necessary structs and where the `cargo` command is built.