### PR TITLE
Ptw/pass remaining args through

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod recipe;
 mod skeleton;
 
-pub use recipe::{CookArgs, DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
+pub use recipe::{CookArgs, OptimisationProfile, Recipe};
 pub use skeleton::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,8 @@ fn test_pass_through() {
         "cook",
         "--recipe-path",
         "./recipe.json",
+        "--no-default-features",
+        "--release",
         "testing",
         "--other-options",
         "yes",
@@ -165,7 +167,10 @@ fn test_pass_through() {
     {
         assert_eq!(
             cargo_options,
+            // NB: options that chef should know about are only in `cargo_options`
             vec![
+                "--no-default-features".into(),
+                "--release".into(),
                 "testing".to_string(),
                 "--other-options".into(),
                 "yes".into()

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,3 +199,10 @@ fn main() -> Result<(), anyhow::Error> {
     env_logger::init();
     _main()
 }
+
+#[test]
+fn test_pass_through() {
+    let args = vec!["cargo", "chef", "cook", "--recipe-path", "./recipe.json"];
+    let cli = Cli::parse_from(args);
+    assert!(matches!(cli, Cli { command: CargoInvocation::Chef { command : Command::Cook {..}}}))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 use anyhow::Context;
-use chef::{CookArgs, DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
+use chef::{CookArgs, OptimisationProfile, Recipe};
 use clap::crate_version;
 use clap::{AppSettings, Clap};
 use fs_err as fs;
-use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// Cache the dependencies of your Rust project.

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -19,14 +19,9 @@ pub struct TargetArgs {
 
 pub struct CookArgs {
     pub profile: OptimisationProfile,
-    pub default_features: DefaultFeatures,
-    pub features: Option<HashSet<String>>,
     pub target: Option<String>,
     pub target_dir: Option<PathBuf>,
-    pub target_args: TargetArgs,
-    pub manifest_path: Option<PathBuf>,
-    pub package: Option<String>,
-    pub workspace: bool,
+    pub cargo_options: Vec<String>,
 }
 
 impl Recipe {
@@ -66,26 +61,14 @@ pub enum DefaultFeatures {
 fn build_dependencies(args: &CookArgs) {
     let CookArgs {
         profile,
-        default_features,
-        features,
         target,
         target_dir,
-        target_args,
-        manifest_path,
-        package,
-        workspace,
+        cargo_options,
     } = args;
     let mut command = Command::new("cargo");
     let command_with_args = command.arg("build");
     if profile == &OptimisationProfile::Release {
         command_with_args.arg("--release");
-    }
-    if default_features == &DefaultFeatures::Disabled {
-        command_with_args.arg("--no-default-features");
-    }
-    if let Some(features) = features {
-        let feature_flag = features.iter().cloned().collect::<Vec<String>>().join(",");
-        command_with_args.arg("--features").arg(feature_flag);
     }
     if let Some(target) = target {
         command_with_args.arg("--target").arg(target);
@@ -93,26 +76,9 @@ fn build_dependencies(args: &CookArgs) {
     if let Some(target_dir) = target_dir {
         command_with_args.arg("--target-dir").arg(target_dir);
     }
-    if target_args.benches {
-        command_with_args.arg("--benches");
-    }
-    if target_args.tests {
-        command_with_args.arg("--tests");
-    }
-    if target_args.examples {
-        command_with_args.arg("--examples");
-    }
-    if target_args.all_targets {
-        command_with_args.arg("--all-targets");
-    }
-    if let Some(manifest_path) = manifest_path {
-        command_with_args.arg("--manifest-path").arg(manifest_path);
-    }
-    if let Some(package) = package {
-        command_with_args.arg("--package").arg(package);
-    }
-    if *workspace {
-        command_with_args.arg("--workspace");
+
+    for arg in cargo_options {
+        command_with_args.arg(arg);
     }
 
     execute_command(command_with_args);

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -9,13 +9,6 @@ pub struct Recipe {
     pub skeleton: Skeleton,
 }
 
-pub struct TargetArgs {
-    pub benches: bool,
-    pub tests: bool,
-    pub examples: bool,
-    pub all_targets: bool,
-}
-
 pub struct CookArgs {
     pub profile: OptimisationProfile,
     pub target: Option<String>,
@@ -49,12 +42,6 @@ impl Recipe {
 pub enum OptimisationProfile {
     Release,
     Debug,
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum DefaultFeatures {
-    Enabled,
-    Disabled,
 }
 
 fn build_dependencies(args: &CookArgs) {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,7 +1,6 @@
 use crate::Skeleton;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::Command;
 


### PR DESCRIPTION
This is an alternate approach to https://github.com/LukeMathWalker/cargo-chef/pull/65.
Instead of establishing option parity with `cargo`, let's just put all options that we don't
use for cleaning up the skeleton directory into a separate `cargo_options` field.

Note! If someone includes an option that we want, say `profile` or `recipe_path`, after an
unknown option, we would include these options for `cargo chef` only for cargo:
```shell
cargo chef --package test --recipe-path ./recipe.json
```
would lead to `./recipe.json` being run in `cargo build`, which doesn't make any sense. 