### PR TITLE
Build one Docker image per Rust version and tag with cargo-chef version number

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,12 +1,16 @@
 name: Build Docker images
 on:
   push:
-    tags:
-      # Do not build on alpha tags!
-      - v[0-9]+.[0-9]+.[0-9]+
-      # NOTE: The job relies on above format being used
+    branches: [main, master]
   schedule:
     - cron: '42 7 * * *' # run at 7:42 UTC (morning) every day
+
+env:
+  RUST_IMAGE_TAG: latest
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  DOCKER_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/cargo-chef
+
 jobs:
   rust_image_tag_matrix:
     name: Generate Rust Docker image tag matrix
@@ -34,10 +38,6 @@ jobs:
       fail-fast: false
       matrix:
         rust_image_tag: ${{fromJSON(needs.rust_image_tag_matrix.outputs.matrix)}}
-    env:
-      RUST_IMAGE_TAG: latest
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       -
         name: Checkout
@@ -52,27 +52,45 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        # Get package version from commit tag, with `v` prefix removed
+        # Get package version from Cargo.toml
         name: Get package version
         id: package_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+        run: |-
+          VER=$(grep -E '^version = ' Cargo.toml | cut -d' ' -f3 | cut -d'"' -f2)
+          echo ::set-output name=result::$VER
+      -
+        # Check if Cargo version matches ^\d+\.\d+\.\d+$
+        name: Determine if release version
+        id: is_release_version
+        run: |
+          if [[ ${{ steps.package_version.outputs.result }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=result::true
+          fi
       -
         name: Build and push
         run: |
           RUST_IMAGE_TAG=${{ matrix.rust_image_tag }}
-          CHEF_PACKAGE_VERSION=${{ steps.package_version.outputs.VERSION }}
-          CHEF_IMAGE=$DOCKERHUB_USERNAME/cargo-chef:$CHEF_PACKAGE_VERSION-rust-$RUST_IMAGE_TAG
-          CHEF_IMAGE_LATEST=$DOCKERHUB_USERNAME/cargo-chef:latest-rust-$RUST_IMAGE_TAG
+          CHEF_PACKAGE_VERSION=${{ steps.package_version.outputs.result }}
+          CHEF_IMAGE=$DOCKER_REPO:$CHEF_PACKAGE_VERSION-rust-$RUST_IMAGE_TAG
 
           docker build -t $CHEF_IMAGE --build-arg=BASE_IMAGE=rust:$RUST_IMAGE_TAG ./docker
-          docker tag $CHEF_IMAGE $CHEF_IMAGE_LATEST
           docker push $CHEF_IMAGE
+      -
+        # Latest cargo-chef version for each Rust version
+        name: Push `latest-rust-X` tag
+        if: ${{ steps.is_release_version.outputs.result == 'true' }}
+        run: |
+          RUST_IMAGE_TAG=${{ matrix.rust_image_tag }}
+          CHEF_PACKAGE_VERSION=${{ steps.package_version.outputs.result }}
+          CHEF_IMAGE=$DOCKER_REPO:$CHEF_PACKAGE_VERSION-rust-$RUST_IMAGE_TAG
+          CHEF_IMAGE_LATEST=$DOCKER_REPO:latest-rust-$RUST_IMAGE_TAG
+
+          docker tag $CHEF_IMAGE $CHEF_IMAGE_LATEST
           docker push $CHEF_IMAGE_LATEST
       -
         # Latest Rust version, latest cargo-chef version
-        name: Push latest tag
-        if: ${{ matrix.rust_image_tag == 'latest' }}
+        name: Push `latest` tag
+        if: ${{ matrix.rust_image_tag == 'latest' && steps.is_release_version.outputs.result == 'true' }}
         run: |
-          REPO=$DOCKERHUB_USERNAME/cargo-chef
-          docker tag $REPO:latest-rust-latest $REPO:latest
-          docker push $REPO:latest
+          docker tag $DOCKER_REPO:latest-rust-latest $DOCKER_REPO:latest
+          docker push $DOCKER_REPO:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,39 +4,75 @@ on:
     tags:
       # Do not build on alpha tags!
       - v[0-9]+.[0-9]+.[0-9]+
+      # NOTE: The job relies on above format being used
   schedule:
     - cron: '42 7 * * *' # run at 7:42 UTC (morning) every day
 jobs:
-  build:
-    name: Build and push
+  rust_image_tag_matrix:
+    name: Generate Rust Docker image tag matrix
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      -
+        id: set-matrix
+        run: |
+          echo -n '::set-output name=matrix::[' \
+          && curl --silent https://raw.githubusercontent.com/docker-library/official-images/master/library/rust \
+            | grep -E Tags: \
+            | cut -d ' ' -f 2- \
+            | sed 's/, /\n/g' \
+            | sed 's/\(.*\)/"\1",/g' \
+            | tr '\n' ' ' \
+            | sed '$ s/..$//' \
+          && echo ']'
+  build_and_push:
+    name: Build and push
+    needs: [rust_image_tag_matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust_image_tag: ${{fromJSON(needs.rust_image_tag_matrix.outputs.matrix)}}
     env:
       RUST_IMAGE_TAG: latest
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - run: |
-          docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_TOKEN
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        # Get package version from commit tag, with `v` prefix removed
+        name: Get package version
+        id: package_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+      -
+        name: Build and push
+        run: |
+          RUST_IMAGE_TAG=${{ matrix.rust_image_tag }}
+          CHEF_PACKAGE_VERSION=${{ steps.package_version.outputs.VERSION }}
+          CHEF_IMAGE=$DOCKERHUB_USERNAME/cargo-chef:$CHEF_PACKAGE_VERSION-rust-$RUST_IMAGE_TAG
+          CHEF_IMAGE_LATEST=$DOCKERHUB_USERNAME/cargo-chef:latest-rust-$RUST_IMAGE_TAG
 
-          RUST_IMAGE=rust:$RUST_IMAGE_TAG
-          RUST_VERSION=$(docker run --rm $RUST_IMAGE rustc --version)
-          echo "Rust version in $RUST_IMAGE is $RUST_VERSION."
-
-          CHEF_IMAGE=$DOCKERHUB_USERNAME/cargo-chef:$RUST_IMAGE_TAG
-          CHEF_RUST_VERSION=$(docker run --rm $CHEF_IMAGE rustc --version || echo "none")
-          echo "Rust version in $CHEF_IMAGE is $CHEF_RUST_VERSION."
-          CHEF_VERSION=$(docker run --rm $CHEF_IMAGE cargo install --list | grep "^cargo-chef v" | cut -d v -f 2 | cut -d : -f 1 || echo "none")
-          echo "cargo chef version in $CHEF_IMAGE is $CHEF_VERSION."
-
-          # Somewhat tricky way to determine latest version without installing anything
-          LATEST_CHEF=$(cargo search --limit 1 cargo-chef | head -n 1 | cut -d '"' -f 2)
-          echo "Latest cargo chef version on crates.io is $LATEST_CHEF."
-
-          if [ "$RUST_VERSION" == "$CHEF_RUST_VERSION" -a "$LATEST_CHEF" == "$CHEF_VERSION" ]; then
-            echo "All versions up-to-date, existing early."
-            exit 0
-          fi
-
-          docker build docker/ -t $CHEF_IMAGE --build-arg=BASE_IMAGE=$RUST_IMAGE
+          docker build -t $CHEF_IMAGE --build-arg=BASE_IMAGE=rust:$RUST_IMAGE_TAG ./docker
+          docker tag $CHEF_IMAGE $CHEF_IMAGE_LATEST
           docker push $CHEF_IMAGE
+          docker push $CHEF_IMAGE_LATEST
+      -
+        # Latest Rust version, latest cargo-chef version
+        name: Push latest tag
+        if: ${{ matrix.rust_image_tag == 'latest' }}
+        run: |
+          REPO=$DOCKERHUB_USERNAME/cargo-chef
+          docker tag $REPO:latest-rust-latest $REPO:latest
+          docker push $REPO:latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-chef"
-version = "0.1.22-alpha.0"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chef"
-version = "0.1.22-alpha.0"
+version = "0.1.22"
 authors = ["Luca Palmieri <lpalmieri@truelayer.com>"]
 edition = "2018"
 description = "A cargo sub-command to build project dependencies for optimal Docker layer caching."

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
 ARG BASE_IMAGE=rust
 FROM $BASE_IMAGE
 
-RUN cargo install cargo-chef && rm -rf $CARGO_HOME/registry/
+# Install musl-dev on Alpine to avoid error "ld: cannot find crti.o: No such file or directory"
+RUN ((cat /etc/os-release | grep ID | grep alpine) && apk add --no-cache musl-dev || true) \
+    && cargo install cargo-chef \
+    && rm -rf $CARGO_HOME/registry/


### PR DESCRIPTION
Pulls current Rust docker image tags from [the official GitHub repo](https://github.com/docker-library/official-images/blob/master/library/rust).

Image tag format looks like this: `{cargo chef version}-rust-{dockerhub rust image tag}`. 

For non-alpha/beta versions of cargo-chef there's also a `latest-rust-{dockerhub rust image tag}` equivalent tag pushed, and a `latest` tag like before (which uses `rust:latest`).

E.g. for a non-alpha/beta version some tags pushed might be:

- `latest`
- `0.1.22-rust-1`
- `latest-rust-1`
- `latest-rust-1.52-buster`
- `0.1.22-rust-1.52.1-alpine3.12`
- `latest-rust-1.52.1-alpine3.12`
- etc...

For alpha/beta versions:

- `0.1.22-alpha.1-rust-1`
- `0.1.22-alpha.1-rust-1.52.1-alpine3.12`
- etc...

I set up a DockerHub repo while testing my changes. So examples of built images can be found here: https://hub.docker.com/repository/docker/jacobsvante/cargo-chef/tags. They were built by this GitHub Actions run: https://github.com/jmagnusson/cargo-chef/actions/runs/946755916

Fixes #58