### PR TITLE
Add a --check flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,9 @@ pub struct Cook {
     /// Build in release mode.
     #[clap(long)]
     release: bool,
+    /// Check instead of build.
+    #[clap(long)]
+    check: bool,
     /// Build for the target triple.
     #[clap(long)]
     target: Option<String>,
@@ -112,6 +115,7 @@ fn _main() -> Result<(), anyhow::Error> {
         Command::Cook(Cook {
             recipe_path,
             release,
+            check,
             target,
             no_default_features,
             features,
@@ -178,6 +182,7 @@ fn _main() -> Result<(), anyhow::Error> {
             recipe
                 .cook(CookArgs {
                     profile,
+                    check,
                     default_features,
                     features,
                     target,

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ pub struct Cook {
     /// Build in release mode.
     #[clap(long)]
     release: bool,
-    /// Check instead of build.
+    /// Run `cargo check` instead of `cargo build`. Primarily useful for speeding up your CI pipeline.
     #[clap(long)]
     check: bool,
     /// Build for the target triple.

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -19,6 +19,7 @@ pub struct TargetArgs {
 
 pub struct CookArgs {
     pub profile: OptimisationProfile,
+    pub check: bool,
     pub default_features: DefaultFeatures,
     pub features: Option<HashSet<String>>,
     pub target: Option<String>,
@@ -67,6 +68,7 @@ pub enum DefaultFeatures {
 fn build_dependencies(args: &CookArgs) {
     let CookArgs {
         profile,
+        check,
         default_features,
         features,
         target,
@@ -78,7 +80,11 @@ fn build_dependencies(args: &CookArgs) {
         offline,
     } = args;
     let mut command = Command::new("cargo");
-    let command_with_args = command.arg("build");
+    let command_with_args = if *check {
+        command.arg("check")
+    } else {
+        command.arg("build")
+    };
     if profile == &OptimisationProfile::Release {
         command_with_args.arg("--release");
     }


### PR DESCRIPTION
I'm working on a CI setup where I want to be able to run both `cargo clippy` and `cargo build`. Without the `--check` flag, we need to rebuild the dependencies for checking each time. With this addition, `cargo clippy` is able to leverage the cache.

Thanks for the wonderful tool, it's really sped up our CI!