### PR TITLE
Add flag for cooking #[no_std] crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "globwalk",
  "log",
  "pathdiff",
+ "predicates",
  "serde",
  "serde_json",
  "toml",
@@ -205,6 +206,15 @@ checksum = "2300477aab3a378f2ca00a4fbd4dc713654ab7ed790e4017493cb33656280633"
 dependencies = [
  "dissimilar",
  "once_cell",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -355,6 +365,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,13 +405,16 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3d91237f5de3bcd9d927e24d03b495adb6135097b001cea7403e2d573d00a9"
+checksum = "c143348f141cc87aab5b950021bac6145d0e5ae754b0591de23244cee42c9308"
 dependencies = [
  "difflib",
+ "float-cmp",
  "itertools",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ expect-test = "1.1.0"
 [dev-dependencies]
 assert_cmd = "1.0.1"
 assert_fs = "1.0.0"
+predicates = "2.0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,9 @@ pub struct Cook {
     /// Build offline.
     #[clap(long)]
     offline: bool,
+    /// Cook using `#[no_std]` configuration  (does not affect `proc-macro` crates)
+    #[clap(long)]
+    no_std: bool,
 }
 
 fn _main() -> Result<(), anyhow::Error> {
@@ -128,6 +131,7 @@ fn _main() -> Result<(), anyhow::Error> {
             package,
             workspace,
             offline,
+            no_std,
         }) => {
             if atty::is(atty::Stream::Stdout) {
                 eprintln!("WARNING stdout appears to be a terminal.");
@@ -192,6 +196,7 @@ fn _main() -> Result<(), anyhow::Error> {
                     package,
                     workspace,
                     offline,
+                    no_std,
                 })
                 .context("Failed to cook recipe.")?;
         }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -29,6 +29,7 @@ pub struct CookArgs {
     pub package: Option<String>,
     pub workspace: bool,
     pub offline: bool,
+    pub no_std: bool,
 }
 
 impl Recipe {
@@ -39,7 +40,8 @@ impl Recipe {
 
     pub fn cook(&self, args: CookArgs) -> Result<(), anyhow::Error> {
         let current_directory = std::env::current_dir()?;
-        self.skeleton.build_minimum_project(&current_directory)?;
+        self.skeleton
+            .build_minimum_project(&current_directory, args.no_std)?;
         build_dependencies(&args);
         self.skeleton
             .remove_compiled_dummies(
@@ -78,6 +80,7 @@ fn build_dependencies(args: &CookArgs) {
         package,
         workspace,
         offline,
+        ..
     } = args;
     let mut command = Command::new("cargo");
     let command_with_args = if *check {

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -118,7 +118,11 @@ impl Skeleton {
     ///
     /// This function should be called on an empty canvas - i.e. an empty directory apart from
     /// the recipe file used to restore the skeleton.
-    pub fn build_minimum_project(&self, base_path: &Path) -> Result<(), anyhow::Error> {
+    pub fn build_minimum_project(
+        &self,
+        base_path: &Path,
+        no_std: bool,
+    ) -> Result<(), anyhow::Error> {
         // Save lockfile to disk, if available
         if let Some(lock_file) = &self.lock_file {
             let lock_file_path = base_path.join("Cargo.lock");
@@ -132,6 +136,15 @@ impl Skeleton {
             fs::create_dir_all(parent_dir)?;
             fs::write(config_file_path, config_file.as_str())?;
         }
+
+        let no_std_entrypoint = "#![no_std]
+#![no_main]
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+";
 
         // Save all manifests to disks
         for manifest in &self.manifests {
@@ -155,7 +168,11 @@ impl Skeleton {
                 if let Some(parent_directory) = binary_path.parent() {
                     fs::create_dir_all(parent_directory)?;
                 }
-                fs::write(binary_path, "fn main() {}")?;
+                if no_std {
+                    fs::write(binary_path, no_std_entrypoint)?;
+                } else {
+                    fs::write(binary_path, "fn main() {}")?;
+                }
             }
 
             // Create dummy entrypoint files for for all libraries
@@ -166,7 +183,11 @@ impl Skeleton {
                 if let Some(parent_directory) = lib_path.parent() {
                     fs::create_dir_all(parent_directory)?;
                 }
-                fs::write(lib_path, "")?;
+                if no_std && !lib.proc_macro {
+                    fs::write(lib_path, "#![no_std]")?;
+                } else {
+                    fs::write(lib_path, "")?;
+                }
             }
 
             // Create dummy entrypoint files for for all benchmarks
@@ -196,7 +217,30 @@ impl Skeleton {
                 if let Some(parent_directory) = test_path.parent() {
                     fs::create_dir_all(parent_directory)?;
                 }
-                if test.harness {
+                if no_std {
+                    if test.harness {
+                        fs::write(
+                            test_path,
+                            r#"#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(test_runner)]
+
+#[no_mangle]
+pub extern "C" fn _init() {}
+
+fn test_runner(_: &[&dyn Fn()]) {}
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+"#,
+                        )?;
+                    } else {
+                        fs::write(test_path, no_std_entrypoint)?;
+                    }
+                } else if test.harness {
                     fs::write(test_path, "")?;
                 } else {
                     fs::write(test_path, "fn main() {}")?;
@@ -215,7 +259,11 @@ impl Skeleton {
                 if let Some(parent_directory) = example_path.parent() {
                     fs::create_dir_all(parent_directory)?;
                 }
-                fs::write(example_path, "fn main() {}")?;
+                if no_std {
+                    fs::write(example_path, no_std_entrypoint)?;
+                } else {
+                    fs::write(example_path, "fn main() {}")?;
+                }
             }
 
             // Create dummy build script file if specified

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -1,7 +1,10 @@
-use assert_fs::prelude::{FileTouch, FileWriteStr, PathChild, PathCreateDir};
+use std::path::Path;
+
+use assert_fs::prelude::*;
 use assert_fs::TempDir;
 use chef::Skeleton;
 use expect_test::Expect;
+use predicates::prelude::*;
 
 #[test]
 pub fn no_workspace() {
@@ -39,10 +42,15 @@ path = "src/main.rs"
 
     // Assert
     assert_eq!(1, skeleton.manifests.len());
-    let manifest = skeleton.manifests[0].clone();
-    assert_eq!("Cargo.toml", manifest.relative_path.to_str().unwrap());
-    assert!(cook_directory.child("src").child("main.rs").path().exists());
-    assert!(cook_directory.child("Cargo.lock").path().exists());
+    let manifest = &skeleton.manifests[0];
+    assert_eq!(Path::new("Cargo.toml"), manifest.relative_path);
+    cook_directory
+        .child("src")
+        .child("main.rs")
+        .assert("fn main() {}");
+    cook_directory
+        .child("Cargo.lock")
+        .assert(predicate::path::exists());
 }
 
 #[test]
@@ -115,20 +123,18 @@ uuid = { version = "=0.8.0", features = ["v4"] }
 
     // Assert
     assert_eq!(3, skeleton.manifests.len());
-    assert!(cook_directory
+    cook_directory
         .child("src")
         .child("project_a")
         .child("src")
         .child("main.rs")
-        .path()
-        .exists());
-    assert!(cook_directory
+        .assert("fn main() {}");
+    cook_directory
         .child("src")
         .child("project_b")
         .child("src")
         .child("lib.rs")
-        .path()
-        .exists())
+        .assert("");
 }
 
 #[test]
@@ -175,13 +181,12 @@ harness = false
 
     // Assert
     assert_eq!(1, skeleton.manifests.len());
-    let manifest = skeleton.manifests[0].clone();
-    assert_eq!("Cargo.toml", manifest.relative_path.to_str().unwrap());
-    assert!(cook_directory
+    let manifest = &skeleton.manifests[0];
+    assert_eq!(Path::new("Cargo.toml"), manifest.relative_path);
+    cook_directory
         .child("benches")
         .child("basics.rs")
-        .path()
-        .exists())
+        .assert("fn main() {}");
 }
 
 #[test]
@@ -222,13 +227,9 @@ name = "foo"
 
     // Assert
     assert_eq!(1, skeleton.manifests.len());
-    let manifest = skeleton.manifests[0].clone();
-    assert_eq!("Cargo.toml", manifest.relative_path.to_str().unwrap());
-    assert!(cook_directory
-        .child("tests")
-        .child("foo.rs")
-        .path()
-        .exists())
+    let manifest = &skeleton.manifests[0];
+    assert_eq!(Path::new("Cargo.toml"), manifest.relative_path);
+    cook_directory.child("tests").child("foo.rs").assert("");
 }
 
 #[test]
@@ -269,13 +270,12 @@ name = "foo"
 
     // Assert
     assert_eq!(1, skeleton.manifests.len());
-    let manifest = skeleton.manifests[0].clone();
-    assert_eq!("Cargo.toml", manifest.relative_path.to_str().unwrap());
-    assert!(cook_directory
+    let manifest = &skeleton.manifests[0];
+    assert_eq!(Path::new("Cargo.toml"), manifest.relative_path);
+    cook_directory
         .child("examples")
         .child("foo.rs")
-        .path()
-        .exists())
+        .assert("fn main() {}");
 }
 
 #[test]
@@ -352,14 +352,16 @@ pub fn config_toml() {
 
     // Assert
     assert_eq!(1, skeleton.manifests.len());
-    let manifest = skeleton.manifests[0].clone();
-    assert_eq!("Cargo.toml", manifest.relative_path.to_str().unwrap());
-    assert!(cook_directory.child("src").child("main.rs").path().exists());
-    assert!(cook_directory
+    let manifest = &skeleton.manifests[0];
+    assert_eq!(Path::new("Cargo.toml"), manifest.relative_path);
+    cook_directory
+        .child("src")
+        .child("main.rs")
+        .assert("fn main() {}");
+    cook_directory
         .child(".cargo")
         .child("config.toml")
-        .path()
-        .exists());
+        .assert(predicate::path::exists());
 }
 
 #[test]

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -34,7 +34,7 @@ path = "src/main.rs"
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert
@@ -110,7 +110,7 @@ uuid = { version = "=0.8.0", features = ["v4"] }
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert
@@ -170,7 +170,7 @@ harness = false
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert
@@ -217,7 +217,7 @@ name = "foo"
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert
@@ -264,7 +264,7 @@ name = "foo"
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert
@@ -347,7 +347,7 @@ pub fn config_toml() {
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert
@@ -394,7 +394,7 @@ pub fn version() {
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert
@@ -447,7 +447,7 @@ version = "1.2.3"
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert
@@ -563,7 +563,7 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
     let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
-        .build_minimum_project(cook_directory.path())
+        .build_minimum_project(cook_directory.path(), false)
         .unwrap();
 
     // Assert


### PR DESCRIPTION
This adds support for using `cargo-chef` with `#[no_std]` crates.

When specifying `--no-std`, an appropriate `#[no_std]` template will be used for generating the skeleton.

On `proc-macro` crates and build scripts, this will be ignored. This allows `#[no_std]` workspaces to be built using `--workspaces`, even when they include `proc-macro` crates. When building workspaces which mix `std` and `#[no_std]` crates, `--no-std` has to be provided on a per crate basis, as there is no easy way to determine the `std`-ness of a crate, as far as I know.

What do you think?