### PR TITLE
Suggest using --locked in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 You can install `cargo-chef` from [crates.io](https://crates.io) with
 
 ```bash
-cargo install cargo-chef
+cargo install cargo-chef --locked
 ```
 
 ## How to use


### PR DESCRIPTION
Since cargo-chef is intended for automated setups, it's better for reproducibility to use the binary's lock file during installation.

There's a relevant comment about `--locked` in `cargo install` docs: https://doc.rust-lang.org/cargo/commands/cargo-install.html