### PR TITLE
Reproducible order

### DIFF
--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -49,9 +49,6 @@ impl Skeleton {
                 // is unchanged).
                 // We replace versions of local crates in `Cargo.lock` using the same dummy version
                 // used to replace versions in `Cargo.toml`s.
-                //
-                // TODO: verify that the substitution strategy works for all versions of the
-                // Cargo.lock format (v1 / v2 / v3)
                 if let Some(packages) = lock
                     .get_mut("package")
                     .and_then(|packages| packages.as_array_mut())

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -1,10 +1,10 @@
-mod version_masking;
 mod read;
+mod version_masking;
 
 use crate::OptimisationProfile;
 use anyhow::Context;
 use fs_err as fs;
-use globwalk::{GlobWalkerBuilder};
+use globwalk::GlobWalkerBuilder;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -37,9 +37,7 @@ impl Skeleton {
 
         version_masking::mask_local_crate_versions(&mut manifests, &mut lock_file);
 
-        let lock_file = lock_file.map(|l| {
-            toml::to_string(&l)
-        }).transpose()?;
+        let lock_file = lock_file.map(|l| toml::to_string(&l)).transpose()?;
 
         let mut serialised_manifests = serialize_manifests(manifests)?;
         // We don't want an ordering issue (e.g. related to how files are read from the filesystem)

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -1,12 +1,12 @@
 mod version_masking;
+mod read;
 
 use crate::OptimisationProfile;
 use anyhow::Context;
 use fs_err as fs;
-use globwalk::{GlobWalkerBuilder, WalkError};
+use globwalk::{GlobWalkerBuilder};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Skeleton {
@@ -31,9 +31,9 @@ impl Skeleton {
     /// Find all Cargo.toml files in `base_path` by traversing sub-directories recursively.
     pub fn derive<P: AsRef<Path>>(base_path: P) -> Result<Self, anyhow::Error> {
         // Read relevant files from the filesystem
-        let mut manifests = read_manifests(&base_path)?;
-        let mut lock_file = read_lockfile(&base_path)?;
-        let config_file = read_config(&base_path)?;
+        let mut manifests = read::manifests(&base_path)?;
+        let mut lock_file = read::lockfile(&base_path)?;
+        let config_file = read::config(&base_path)?;
 
         version_masking::mask_local_crate_versions(&mut manifests, &mut lock_file);
 
@@ -287,109 +287,6 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
     }
 }
 
-/// What should we should when we encounter an issue while walking the current directory?
-///
-/// If `ErrorStrategy::Ignore`, just skip the file/directory and keep going.
-/// If `ErrorStrategy::Crash`, stop exploring and return an error to the caller.
-enum ErrorStrategy {
-    Ignore,
-    Crash(WalkError),
-}
-
-/// Ignore directory/files for which we don't have enough permissions to perform our scan.
-#[must_use]
-fn handle_walk_error(e: WalkError) -> ErrorStrategy {
-    if let Some(inner) = e.io_error() {
-        if std::io::ErrorKind::PermissionDenied == inner.kind() {
-            log::warn!("Missing permission to read entry: {}\nSkipping.", inner);
-            return ErrorStrategy::Ignore;
-        }
-    }
-    ErrorStrategy::Crash(e)
-}
-
-fn read_config<P: AsRef<Path>>(
-    base_path: &P,
-) -> Result<Option<String>, anyhow::Error> {
-    // Given that we run primarily in Docker, assume to find config.toml at root level.
-    match fs::read_to_string(base_path.as_ref().join(".cargo/config.toml")) {
-        Ok(config) => Ok(Some(config)),
-        Err(e) => {
-            if std::io::ErrorKind::NotFound != e.kind() {
-                return Err(
-                    anyhow::Error::from(e).context("Failed to read .cargo/config.toml file.")
-                );
-            }
-            Ok(None)
-        }
-    }
-}
-
-fn read_manifests<P: AsRef<Path>>(
-    base_path: &P,
-) -> Result<Vec<ParsedManifest>, anyhow::Error> {
-    let walker = GlobWalkerBuilder::new(&base_path, "/**/Cargo.toml")
-        .build()
-        .context("Failed to scan the files in the current directory.")?;
-
-    let mut manifests = vec![];
-    for manifest in walker {
-        match manifest {
-            Ok(manifest) => {
-                let absolute_path = manifest.path().to_path_buf();
-                let contents = fs::read_to_string(&absolute_path)?;
-
-                let mut parsed = cargo_manifest::Manifest::from_str(&contents)?;
-                // Required to detect bin/libs when the related section is omitted from the manifest
-                parsed.complete_from_path(&absolute_path)?;
-
-                let mut intermediate = toml::Value::try_from(parsed)?;
-
-                // Specifically, toml gives no guarantees to the ordering of the auto binaries
-                // in its results. We will manually sort these to ensure that the output
-                // manifest will match.
-                let bins = intermediate
-                    .get_mut("bin")
-                    .and_then(|bins| bins.as_array_mut());
-                if let Some(bins) = bins {
-                    bins.sort_by(|bin_a, bin_b| {
-                        let bin_a_path = bin_a
-                            .as_table()
-                            .and_then(|table| table.get("path"))
-                            .and_then(|path| path.as_str())
-                            .unwrap();
-                        let bin_b_path = bin_b
-                            .as_table()
-                            .and_then(|table| table.get("path"))
-                            .and_then(|path| path.as_str())
-                            .unwrap();
-                        bin_a_path.cmp(bin_b_path)
-                    });
-                }
-
-                let relative_path =
-                    pathdiff::diff_paths(&absolute_path, &base_path).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Failed to compute relative path of manifest {:?}",
-                            &absolute_path
-                        )
-                    })?;
-                manifests.push(ParsedManifest {
-                    relative_path,
-                    contents: intermediate,
-                });
-            }
-            Err(e) => match handle_walk_error(e) {
-                ErrorStrategy::Ignore => {}
-                ErrorStrategy::Crash(e) => {
-                    return Err(e.into());
-                }
-            },
-        }
-    }
-    Ok(manifests)
-}
-
 fn serialize_manifests(manifests: Vec<ParsedManifest>) -> Result<Vec<Manifest>, anyhow::Error> {
     let mut serialised_manifests = vec![];
     for manifest in manifests {
@@ -401,21 +298,4 @@ fn serialize_manifests(manifests: Vec<ParsedManifest>) -> Result<Vec<Manifest>, 
         });
     }
     Ok(serialised_manifests)
-}
-
-fn read_lockfile<P: AsRef<Path>>(
-    base_path: &P,
-) -> Result<Option<toml::Value>, anyhow::Error> {
-    match fs::read_to_string(base_path.as_ref().join("Cargo.lock")) {
-        Ok(lock) => {
-            let lock: toml::Value = toml::from_str(&lock)?;
-            Ok(Some(lock))
-        }
-        Err(e) => {
-            if std::io::ErrorKind::NotFound != e.kind() {
-                return Err(anyhow::Error::from(e).context("Failed to read Cargo.lock file."));
-            }
-            Ok(None)
-        }
-    }
 }

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -1,6 +1,7 @@
+mod version_masking;
+
 use crate::OptimisationProfile;
 use anyhow::Context;
-use cargo_manifest::Value;
 use fs_err as fs;
 use globwalk::{GlobWalkerBuilder, WalkError};
 use serde::{Deserialize, Serialize};
@@ -21,7 +22,7 @@ pub struct Manifest {
     pub contents: String,
 }
 
-struct ParsedManifest {
+pub(in crate::skeleton) struct ParsedManifest {
     relative_path: PathBuf,
     contents: toml::Value,
 }
@@ -34,7 +35,7 @@ impl Skeleton {
         let mut lock_file = read_lockfile(&base_path)?;
         let config_file = read_config(&base_path)?;
 
-        mask_local_crate_versions(&mut manifests, &mut lock_file);
+        version_masking::mask_local_crate_versions(&mut manifests, &mut lock_file);
 
         let lock_file = lock_file.map(|l| {
             toml::to_string(&l)
@@ -418,89 +419,3 @@ fn read_lockfile<P: AsRef<Path>>(
         }
     }
 }
-
-
-/// All local dependencies are emptied out when running `prepare`.
-/// We do not want the recipe file to change if the only difference with
-/// the previous docker build attempt is the version of a local crate
-/// encoded in `Cargo.lock` (while the remote dependency tree
-/// is unchanged) or in the corresponding `Cargo.toml` manifest.
-/// We replace versions of local crates in `Cargo.lock` and in all `Cargo.toml`s, including
-/// when specified as dependency of another crate in the workspace.
-fn mask_local_crate_versions(mut manifests: &mut [ParsedManifest], mut lock_file: &mut Option<Value>) {
-    fn mask_local_versions_in_lockfile(lock_file: &mut toml::Value, local_package_names: &[Value]) {
-        if let Some(packages) = lock_file
-            .get_mut("package")
-            .and_then(|packages| packages.as_array_mut())
-        {
-            packages
-                .iter_mut()
-                // Find all local crates
-                .filter(|package| {
-                    package
-                        .get("name")
-                        .map(|name| local_package_names.contains(name))
-                        .unwrap_or_default()
-                })
-                // Mask the version
-                .for_each(|package| {
-                    if let Some(version) = package.get_mut("version") {
-                        *version = toml::Value::String(CONST_VERSION.to_string())
-                    }
-                });
-        }
-    }
-
-    fn mask_local_versions_in_manifests(manifests: &mut [ParsedManifest], local_package_names: &[Value]) {
-        for manifest in manifests.iter_mut() {
-            if let Some(package) = manifest.contents.get_mut("package") {
-                if let Some(version) = package.get_mut("version") {
-                    *version = toml::Value::String(CONST_VERSION.to_string());
-                }
-            }
-            mask_local_dependency_versions(local_package_names, manifest, "dependencies");
-            mask_local_dependency_versions(local_package_names, manifest, "dev-dependencies");
-            mask_local_dependency_versions(local_package_names, manifest, "build-dependencies");
-        }
-    }
-
-    fn mask_local_dependency_versions(
-        local_package_names: &[Value],
-        manifest: &mut ParsedManifest,
-        dependency_key: &str,
-    ) {
-        if let Some(dependencies) = manifest.contents.get_mut(dependency_key) {
-            for local_package in local_package_names.iter() {
-                if let toml::Value::String(local_package) = local_package {
-                    let local_package = local_package.replace("-", "_");
-                    if let Some(local_dependency) = dependencies.get_mut(local_package) {
-                        if let Some(version) = local_dependency.get_mut("version") {
-                            *version = toml::Value::String(CONST_VERSION.to_string());
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn parse_local_crate_names(manifests: &[ParsedManifest]) -> Vec<toml::Value> {
-        let mut local_package_names = vec![];
-        for manifest in manifests.iter() {
-            if let Some(package) = manifest.contents.get("package") {
-                if let Some(name) = package.get("name") {
-                    local_package_names.push(name.to_owned());
-                }
-            }
-        }
-        local_package_names
-    }
-
-    const CONST_VERSION: &str = "0.0.1";
-
-    let local_package_names = parse_local_crate_names(&manifests);
-    mask_local_versions_in_manifests(&mut manifests, &local_package_names);
-    if let Some(l) = &mut lock_file {
-        mask_local_versions_in_lockfile(l, &local_package_names);
-    }
-}
-

--- a/src/skeleton/read.rs
+++ b/src/skeleton/read.rs
@@ -1,0 +1,127 @@
+//! Logic to read all the files required to build a caching layer for a project.
+use super::ParsedManifest;
+use std::path::Path;
+use globwalk::{WalkError, GlobWalkerBuilder};
+use std::fs;
+use std::str::FromStr;
+use anyhow::Context;
+
+pub(super) fn config<P: AsRef<Path>>(
+    base_path: &P,
+) -> Result<Option<String>, anyhow::Error> {
+    // Given that we run primarily in Docker, assume to find config.toml at root level.
+    match fs::read_to_string(base_path.as_ref().join(".cargo/config.toml")) {
+        Ok(config) => Ok(Some(config)),
+        Err(e) => {
+            if std::io::ErrorKind::NotFound != e.kind() {
+                return Err(
+                    anyhow::Error::from(e).context("Failed to read .cargo/config.toml file.")
+                );
+            }
+            Ok(None)
+        }
+    }
+}
+
+pub(super) fn manifests<P: AsRef<Path>>(
+    base_path: &P,
+) -> Result<Vec<ParsedManifest>, anyhow::Error> {
+    let walker = GlobWalkerBuilder::new(&base_path, "/**/Cargo.toml")
+        .build()
+        .context("Failed to scan the files in the current directory.")?;
+
+    let mut manifests = vec![];
+    for manifest in walker {
+        match manifest {
+            Ok(manifest) => {
+                let absolute_path = manifest.path().to_path_buf();
+                let contents = fs::read_to_string(&absolute_path)?;
+
+                let mut parsed = cargo_manifest::Manifest::from_str(&contents)?;
+                // Required to detect bin/libs when the related section is omitted from the manifest
+                parsed.complete_from_path(&absolute_path)?;
+
+                let mut intermediate = toml::Value::try_from(parsed)?;
+
+                // Specifically, toml gives no guarantees to the ordering of the auto binaries
+                // in its results. We will manually sort these to ensure that the output
+                // manifest will match.
+                let bins = intermediate
+                    .get_mut("bin")
+                    .and_then(|bins| bins.as_array_mut());
+                if let Some(bins) = bins {
+                    bins.sort_by(|bin_a, bin_b| {
+                        let bin_a_path = bin_a
+                            .as_table()
+                            .and_then(|table| table.get("path"))
+                            .and_then(|path| path.as_str())
+                            .unwrap();
+                        let bin_b_path = bin_b
+                            .as_table()
+                            .and_then(|table| table.get("path"))
+                            .and_then(|path| path.as_str())
+                            .unwrap();
+                        bin_a_path.cmp(bin_b_path)
+                    });
+                }
+
+                let relative_path =
+                    pathdiff::diff_paths(&absolute_path, &base_path).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Failed to compute relative path of manifest {:?}",
+                            &absolute_path
+                        )
+                    })?;
+                manifests.push(ParsedManifest {
+                    relative_path,
+                    contents: intermediate,
+                });
+            }
+            Err(e) => match handle_walk_error(e) {
+                ErrorStrategy::Ignore => {}
+                ErrorStrategy::Crash(e) => {
+                    return Err(e.into());
+                }
+            },
+        }
+    }
+    Ok(manifests)
+}
+
+pub(super) fn lockfile<P: AsRef<Path>>(
+    base_path: &P,
+) -> Result<Option<toml::Value>, anyhow::Error> {
+    match fs::read_to_string(base_path.as_ref().join("Cargo.lock")) {
+        Ok(lock) => {
+            let lock: toml::Value = toml::from_str(&lock)?;
+            Ok(Some(lock))
+        }
+        Err(e) => {
+            if std::io::ErrorKind::NotFound != e.kind() {
+                return Err(anyhow::Error::from(e).context("Failed to read Cargo.lock file."));
+            }
+            Ok(None)
+        }
+    }
+}
+
+/// What should we should when we encounter an issue while walking the current directory?
+///
+/// If `ErrorStrategy::Ignore`, just skip the file/directory and keep going.
+/// If `ErrorStrategy::Crash`, stop exploring and return an error to the caller.
+enum ErrorStrategy {
+    Ignore,
+    Crash(WalkError),
+}
+
+/// Ignore directory/files for which we don't have enough permissions to perform our scan.
+#[must_use]
+fn handle_walk_error(e: WalkError) -> ErrorStrategy {
+    if let Some(inner) = e.io_error() {
+        if std::io::ErrorKind::PermissionDenied == inner.kind() {
+            log::warn!("Missing permission to read entry: {}\nSkipping.", inner);
+            return ErrorStrategy::Ignore;
+        }
+    }
+    ErrorStrategy::Crash(e)
+}

--- a/src/skeleton/read.rs
+++ b/src/skeleton/read.rs
@@ -1,14 +1,12 @@
 //! Logic to read all the files required to build a caching layer for a project.
 use super::ParsedManifest;
-use std::path::Path;
-use globwalk::{WalkError, GlobWalkerBuilder};
-use std::fs;
-use std::str::FromStr;
 use anyhow::Context;
+use globwalk::{GlobWalkerBuilder, WalkError};
+use std::fs;
+use std::path::Path;
+use std::str::FromStr;
 
-pub(super) fn config<P: AsRef<Path>>(
-    base_path: &P,
-) -> Result<Option<String>, anyhow::Error> {
+pub(super) fn config<P: AsRef<Path>>(base_path: &P) -> Result<Option<String>, anyhow::Error> {
     // Given that we run primarily in Docker, assume to find config.toml at root level.
     match fs::read_to_string(base_path.as_ref().join(".cargo/config.toml")) {
         Ok(config) => Ok(Some(config)),

--- a/src/skeleton/version_masking.rs
+++ b/src/skeleton/version_masking.rs
@@ -1,0 +1,87 @@
+use super::ParsedManifest;
+
+/// All local dependencies are emptied out when running `prepare`.
+/// We do not want the recipe file to change if the only difference with
+/// the previous docker build attempt is the version of a local crate
+/// encoded in `Cargo.lock` (while the remote dependency tree
+/// is unchanged) or in the corresponding `Cargo.toml` manifest.
+/// We replace versions of local crates in `Cargo.lock` and in all `Cargo.toml`s, including
+/// when specified as dependency of another crate in the workspace.
+pub(super) fn mask_local_crate_versions(mut manifests: &mut [ParsedManifest], mut lock_file: &mut Option<toml::Value>) {
+
+    let local_package_names = parse_local_crate_names(&manifests);
+    mask_local_versions_in_manifests(&mut manifests, &local_package_names);
+    if let Some(l) = &mut lock_file {
+        mask_local_versions_in_lockfile(l, &local_package_names);
+    }
+}
+
+/// Dummy version used for all local crates.
+const CONST_VERSION: &str = "0.0.1";
+
+fn mask_local_versions_in_lockfile(lock_file: &mut toml::Value, local_package_names: &[toml::Value]) {
+    if let Some(packages) = lock_file
+        .get_mut("package")
+        .and_then(|packages| packages.as_array_mut())
+    {
+        packages
+            .iter_mut()
+            // Find all local crates
+            .filter(|package| {
+                package
+                    .get("name")
+                    .map(|name| local_package_names.contains(name))
+                    .unwrap_or_default()
+            })
+            // Mask the version
+            .for_each(|package| {
+                if let Some(version) = package.get_mut("version") {
+                    *version = toml::Value::String(CONST_VERSION.to_string())
+                }
+            });
+    }
+}
+
+fn mask_local_versions_in_manifests(manifests: &mut [ParsedManifest], local_package_names: &[toml::Value]) {
+    for manifest in manifests.iter_mut() {
+        if let Some(package) = manifest.contents.get_mut("package") {
+            if let Some(version) = package.get_mut("version") {
+                *version = toml::Value::String(CONST_VERSION.to_string());
+            }
+        }
+        mask_local_dependency_versions(local_package_names, manifest, "dependencies");
+        mask_local_dependency_versions(local_package_names, manifest, "dev-dependencies");
+        mask_local_dependency_versions(local_package_names, manifest, "build-dependencies");
+    }
+}
+
+fn mask_local_dependency_versions(
+    local_package_names: &[toml::Value],
+    manifest: &mut ParsedManifest,
+    dependency_key: &str,
+) {
+    if let Some(dependencies) = manifest.contents.get_mut(dependency_key) {
+        for local_package in local_package_names.iter() {
+            if let toml::Value::String(local_package) = local_package {
+                let local_package = local_package.replace("-", "_");
+                if let Some(local_dependency) = dependencies.get_mut(local_package) {
+                    if let Some(version) = local_dependency.get_mut("version") {
+                        *version = toml::Value::String(CONST_VERSION.to_string());
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn parse_local_crate_names(manifests: &[ParsedManifest]) -> Vec<toml::Value> {
+    let mut local_package_names = vec![];
+    for manifest in manifests.iter() {
+        if let Some(package) = manifest.contents.get("package") {
+            if let Some(name) = package.get("name") {
+                local_package_names.push(name.to_owned());
+            }
+        }
+    }
+    local_package_names
+}

--- a/src/skeleton/version_masking.rs
+++ b/src/skeleton/version_masking.rs
@@ -8,12 +8,12 @@ use super::ParsedManifest;
 /// We replace versions of local crates in `Cargo.lock` and in all `Cargo.toml`s, including
 /// when specified as dependency of another crate in the workspace.
 pub(super) fn mask_local_crate_versions(
-    mut manifests: &mut [ParsedManifest],
-    mut lock_file: &mut Option<toml::Value>,
+    manifests: &mut [ParsedManifest],
+    lock_file: &mut Option<toml::Value>,
 ) {
-    let local_package_names = parse_local_crate_names(&manifests);
-    mask_local_versions_in_manifests(&mut manifests, &local_package_names);
-    if let Some(l) = &mut lock_file {
+    let local_package_names = parse_local_crate_names(manifests);
+    mask_local_versions_in_manifests(manifests, &local_package_names);
+    if let Some(l) = lock_file {
         mask_local_versions_in_lockfile(l, &local_package_names);
     }
 }

--- a/src/skeleton/version_masking.rs
+++ b/src/skeleton/version_masking.rs
@@ -7,8 +7,10 @@ use super::ParsedManifest;
 /// is unchanged) or in the corresponding `Cargo.toml` manifest.
 /// We replace versions of local crates in `Cargo.lock` and in all `Cargo.toml`s, including
 /// when specified as dependency of another crate in the workspace.
-pub(super) fn mask_local_crate_versions(mut manifests: &mut [ParsedManifest], mut lock_file: &mut Option<toml::Value>) {
-
+pub(super) fn mask_local_crate_versions(
+    mut manifests: &mut [ParsedManifest],
+    mut lock_file: &mut Option<toml::Value>,
+) {
     let local_package_names = parse_local_crate_names(&manifests);
     mask_local_versions_in_manifests(&mut manifests, &local_package_names);
     if let Some(l) = &mut lock_file {
@@ -19,7 +21,10 @@ pub(super) fn mask_local_crate_versions(mut manifests: &mut [ParsedManifest], mu
 /// Dummy version used for all local crates.
 const CONST_VERSION: &str = "0.0.1";
 
-fn mask_local_versions_in_lockfile(lock_file: &mut toml::Value, local_package_names: &[toml::Value]) {
+fn mask_local_versions_in_lockfile(
+    lock_file: &mut toml::Value,
+    local_package_names: &[toml::Value],
+) {
     if let Some(packages) = lock_file
         .get_mut("package")
         .and_then(|packages| packages.as_array_mut())
@@ -42,7 +47,10 @@ fn mask_local_versions_in_lockfile(lock_file: &mut toml::Value, local_package_na
     }
 }
 
-fn mask_local_versions_in_manifests(manifests: &mut [ParsedManifest], local_package_names: &[toml::Value]) {
+fn mask_local_versions_in_manifests(
+    manifests: &mut [ParsedManifest],
+    local_package_names: &[toml::Value],
+) {
     for manifest in manifests.iter_mut() {
         if let Some(package) = manifest.contents.get_mut("package") {
             if let Some(version) = package.get_mut("version") {

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -803,7 +803,7 @@ version = "0.8.0"
             harness = true
             required-features = []
             crate-type = ["cdylib"]
-        "#]]
+        "#]],
     );
 }
 

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -616,83 +616,83 @@ version = "0.8.0"
     check(
         &second.contents,
         expect_test::expect![[r#"
-        bin = []
-        bench = []
-        test = []
-        example = []
+            bench = []
+            test = []
+            example = []
 
-        [package]
-        name = "project_b"
-        edition = "2018"
-        version = "0.0.1"
-        authors = []
-        keywords = []
-        categories = []
-        autobins = true
-        autoexamples = true
-        autotests = true
-        autobenches = true
-        publish = true
-        [dependencies.project_a]
-        version = "0.0.1"
-        path = "../project_a"
-        features = []
-        optional = false
+            [[bin]]
+            path = "src/main.rs"
+            name = "test-dummy"
+            test = true
+            doctest = true
+            bench = true
+            doc = true
+            plugin = false
+            proc-macro = false
+            harness = true
+            required-features = []
 
-        [dependencies.uuid]
-        version = "=0.8.0"
-        features = ["v4"]
-        optional = false
-
-        [lib]
-        test = true
-        doctest = true
-        bench = true
-        doc = true
-        plugin = false
-        proc-macro = false
-        harness = true
-        required-features = []
-        crate-type = ["cdylib"]
-    "#]],
+            [package]
+            name = "project-a"
+            edition = "2018"
+            version = "0.0.1"
+            authors = []
+            keywords = []
+            categories = []
+            autobins = true
+            autoexamples = true
+            autotests = true
+            autobenches = true
+            publish = true
+            [dependencies.uuid]
+            version = "=0.8.0"
+            features = ["v4"]
+            optional = false
+        "#]],
     );
     let third = skeleton.manifests[2].clone();
     check(
         &third.contents,
         expect_test::expect![[r#"
-        bench = []
-        test = []
-        example = []
+            bin = []
+            bench = []
+            test = []
+            example = []
 
-        [[bin]]
-        path = "src/main.rs"
-        name = "test-dummy"
-        test = true
-        doctest = true
-        bench = true
-        doc = true
-        plugin = false
-        proc-macro = false
-        harness = true
-        required-features = []
+            [package]
+            name = "project_b"
+            edition = "2018"
+            version = "0.0.1"
+            authors = []
+            keywords = []
+            categories = []
+            autobins = true
+            autoexamples = true
+            autotests = true
+            autobenches = true
+            publish = true
+            [dependencies.project_a]
+            version = "0.0.1"
+            path = "../project_a"
+            features = []
+            optional = false
 
-        [package]
-        name = "project-a"
-        edition = "2018"
-        version = "0.0.1"
-        authors = []
-        keywords = []
-        categories = []
-        autobins = true
-        autoexamples = true
-        autotests = true
-        autobenches = true
-        publish = true
-        [dependencies.uuid]
-        version = "=0.8.0"
-        features = ["v4"]
-        optional = false
-    "#]],
+            [dependencies.uuid]
+            version = "=0.8.0"
+            features = ["v4"]
+            optional = false
+
+            [lib]
+            test = true
+            doctest = true
+            bench = true
+            doc = true
+            plugin = false
+            proc-macro = false
+            harness = true
+            required-features = []
+            crate-type = ["cdylib"]
+        "#]]
     );
 }
 


### PR DESCRIPTION
Ensures that our recipe file is unchanged regardless of the order we read manifests from the filesystem.

We use the occasion to refactor the code in `Skeleton::derive`.