### PR TITLE
fix alpine instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 # Notice that we are specifying the --target flag!
-RUN cargo chef cook --bin app --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --release --target x86_64-unknown-linux-musl --bin app
 
 FROM alpine AS runtime
 RUN addgroup -S myuser && adduser -S myuser -G myuser


### PR DESCRIPTION
The alpine build instructions in the readme will fail if copied because some arguments were being passed at the wrong time. This change makes it work