### PR TITLE
Slightly more precise library artifact cleanup

### DIFF
--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -251,9 +251,12 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
                 // Remove dummy libraries.
                 for lib in &parsed_manifest.lib {
                     let library_name = lib.name.as_ref().unwrap_or(&package.name).replace("-", "_");
-                    let walker = GlobWalkerBuilder::new(
+                    let walker = GlobWalkerBuilder::from_patterns(
                         &target_directory,
-                        format!("/**/lib{}*", library_name),
+                        &[
+                            format!("/**/lib{}.*", library_name),
+                            format!("/**/lib{}-*", library_name),
+                        ],
                     )
                     .build()?;
                     for file in walker {


### PR DESCRIPTION
`cargo chef cook` will remove dummy compiled artifacts based off a couple of globs. The glob to remove library artifacts; however, can be a bit too eager and can match other libraries that are prefixed by the name of the desired library. Specifically this was noticed when the compiled artifacts of `libc` were getting removed while trying to remove the artifacts for a library simply named `lib`.

I believe the new globs should cover the patterns we want since library names are limited to just alphanumeric characters, `_`, and `-` with the hypen getting normalized to an underscore, so the new globs will match entries like

```text
liblib-<hash>.rlib
liblib-<hash>.rmeta
liblib.rlib
liblib.d
```

while not matching

```text
liblibc-<hash>.rlib
liblibc-<hash>.rmeta
```