### PR TITLE
Update clap from v3.0 beta 2 to v3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,6 @@ dependencies = [
  "atty",
  "cargo-manifest",
  "clap",
- "clap_derive",
  "env_logger",
  "expect-test",
  "fs-err",
@@ -121,9 +120,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -134,15 +133,13 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.2"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -272,12 +269,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -387,9 +381,12 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "pathdiff"
@@ -644,12 +641,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thread_local"
@@ -677,28 +671,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 atty = "0.2.14"
-clap = "=3.0.0-beta.2"
-clap_derive = "=3.0.0-beta.2"
+clap = { version = "3.1.2", features = ["cargo", "env", "derive"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 log = "0.4.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 use anyhow::Context;
 use chef::{CookArgs, DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
 use clap::crate_version;
-use clap::Clap;
+use clap::Parser;
 use fs_err as fs;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// Cache the dependencies of your Rust project.
-#[derive(Clap)]
+#[derive(Parser)]
 #[clap(
     bin_name = "cargo",
     version = crate_version!(),
@@ -18,7 +18,7 @@ pub struct Cli {
     command: CargoInvocation,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 pub enum CargoInvocation {
     // All `cargo` subcommands receive their name (e.g. `chef` as the first command).
     // See https://github.com/rust-lang/rustfmt/pull/3569
@@ -28,7 +28,7 @@ pub enum CargoInvocation {
     },
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 #[clap(
     version = crate_version!(),
     author = "Luca Palmieri <rust@lpalmieri.com>"
@@ -45,7 +45,7 @@ pub enum Command {
     Cook(Cook),
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 pub struct Prepare {
     /// The filepath used to save the computed recipe.
     ///
@@ -54,7 +54,7 @@ pub struct Prepare {
     recipe_path: PathBuf,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 pub struct Cook {
     /// The filepath `cook` should be reading the recipe from.
     ///
@@ -77,7 +77,7 @@ pub struct Cook {
     #[clap(long)]
     no_default_features: bool,
     /// Space or comma separated list of features to activate.
-    #[clap(long, use_delimiter = true, value_delimiter = ",")]
+    #[clap(long, value_delimiter = ',')]
     features: Option<Vec<String>>,
     /// Build all benches
     #[clap(long)]


### PR DESCRIPTION
Nothing too exciting, just updates clap to the most recent version.

This change is actually because I noticed a slight inconsistency where `cargo` would accept `--features=` as default features while `cargo-chef` rejected it as missing a value. Looking into this further, I noticed that `clap` changed this behavior to match `cargo` in one of the more recent releases, so this PR fixes this minor CLI inconsistency