### PR TITLE
Publish linux musl binaries on release too

### DIFF
--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -16,19 +16,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload-assets:
+    name: upload-assets (${{ matrix.os }} ${{ matrix.target }})
+    needs:
+      - create-release
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cargo-chef
-          archive: $bin-$tag-$target
+          target: ${{ matrix.target }}
           tar: unix
           zip: windows
         env:


### PR DESCRIPTION
This adds publishing Linux musl based binaries to the releases. The changes are mostly a blend of the current implementation and [`cargo-hack`'s upload-assets job](https://github.com/taiki-e/cargo-hack/blob/main/.github/workflows/release.yml#L47-L82)

This is useful for when you need a musl build and the pre-build images don't quite cut it like building an alpine image with a nightly toolchain for instance