### PR TITLE
Ptw/issue 74 Do not skelefy vendored directory

### DIFF
--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -31,9 +31,9 @@ impl Skeleton {
     /// Find all Cargo.toml files in `base_path` by traversing sub-directories recursively.
     pub fn derive<P: AsRef<Path>>(base_path: P) -> Result<Self, anyhow::Error> {
         // Read relevant files from the filesystem
-        let mut manifests = read::manifests(&base_path)?;
-        let mut lock_file = read::lockfile(&base_path)?;
         let config_file = read::config(&base_path)?;
+        let mut manifests = read::manifests(&base_path, config_file.as_deref())?;
+        let mut lock_file = read::lockfile(&base_path)?;
 
         version_masking::mask_local_crate_versions(&mut manifests, &mut lock_file);
 

--- a/src/skeleton/read.rs
+++ b/src/skeleton/read.rs
@@ -38,7 +38,7 @@ pub(super) fn manifests<P: AsRef<Path>>(
 ) -> Result<Vec<ParsedManifest>, anyhow::Error> {
     let vendored_path = vendored_directory(config_contents);
     let builder = if let Some(path) = vendored_path {
-        let exclude_vendored_sources = "!".to_string() + &path;
+        let exclude_vendored_sources = format!("!{}", path);
         GlobWalkerBuilder::from_patterns(&base_path, &["/**/Cargo.toml", &exclude_vendored_sources])
     } else {
         GlobWalkerBuilder::new(&base_path, "/**/Cargo.toml")

--- a/src/skeleton/read.rs
+++ b/src/skeleton/read.rs
@@ -59,7 +59,6 @@ pub(super) fn manifests<P: AsRef<Path>>(
                 parsed.complete_from_path(&absolute_path)?;
 
                 let mut intermediate = toml::Value::try_from(parsed)?;
-                println!("{:?}", intermediate);
 
                 // Specifically, toml gives no guarantees to the ordering of the auto binaries
                 // in its results. We will manually sort these to ensure that the output


### PR DESCRIPTION
This is a quick stab at addressing https://github.com/LukeMathWalker/cargo-chef/issues/74.

There are two design questions: 
1. whether we filter these vendored `Cargo.toml` files from our list of manifests, or include them in the skeleton and then filter them out when we are `cooking`, and
2. How much do we want to hardcode to `cargo vendor`'s behavior.

Regarding 1., I prefer to filter these vendored files from our list of manifests. This makes testing easier (than having to render the recipe then checking directory outputs), keeps the manifests in the skeleton we serialize focused on what which projects we need to skelefy, and is robust against vendored files changing: if a vendored file changes the Docker sha of the step will change so it doesn't matter that the recipe.json file doesn't change---the recipe file will be recomputed by Docker anyway since one of its dependencies in the Dockerfile changed. I am happy to listen to feedback and preferences if this is not the direction the project wants to go.

Regarding 2., `cargo vendor`'s configuration currently looks like: 
```
[source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
```
while `cargo-local-registry` is something like:
```
[source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
local-registry = "vendor"
```
(cargo local registry downloads sources as tarballs, so cargo chef happily ignores them)

I think that going through `crates-io` to the other field is more robust to different project structures, though I was definitely tempted to go straight to `vendored-sources`.