### PR TITLE
Add optional member flag to `prepare`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ pub struct Prepare {
     /// the whole workspace over. Cargo will complain that it can't
     /// find those members, so this replaces all of the members.
     #[clap(long)]
-    member: Option<String>,
+    bin: Option<String>,
 }
 
 #[derive(Parser)]
@@ -114,6 +114,12 @@ pub struct Cook {
     /// Cook using `#[no_std]` configuration  (does not affect `proc-macro` crates)
     #[clap(long)]
     no_std: bool,
+    /// Optional: the member in the workspace we wish to compile.
+    /// Note that this is useful in scenarios where we don't copy
+    /// the whole workspace over. Cargo will complain that it can't
+    /// find those members, so this replaces all of the members.
+    #[clap(long)]
+    bin: Option<String>,
 }
 
 fn _main() -> Result<(), anyhow::Error> {
@@ -143,6 +149,7 @@ fn _main() -> Result<(), anyhow::Error> {
             workspace,
             offline,
             no_std,
+            bin: _bin,
         }) => {
             if atty::is(atty::Stream::Stdout) {
                 eprintln!("WARNING stdout appears to be a terminal.");
@@ -211,12 +218,9 @@ fn _main() -> Result<(), anyhow::Error> {
                 })
                 .context("Failed to cook recipe.")?;
         }
-        Command::Prepare(Prepare {
-            recipe_path,
-            member,
-        }) => {
+        Command::Prepare(Prepare { recipe_path, bin }) => {
             let recipe =
-                Recipe::prepare(current_directory, member).context("Failed to compute recipe")?;
+                Recipe::prepare(current_directory, bin).context("Failed to compute recipe")?;
             let serialized =
                 serde_json::to_string(&recipe).context("Failed to serialize recipe.")?;
             fs::write(recipe_path, serialized).context("Failed to save recipe to 'recipe.json'")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,8 @@ pub struct Prepare {
     #[clap(long, default_value = "recipe.json")]
     recipe_path: PathBuf,
 
-    /// Optional: the name of the binary we wish to compile.
-    /// Note that this is useful in scenarios where we don't copy
-    /// the whole workspace over. Cargo will complain that it can't
-    /// find those members, so this replaces all of the members.
+    /// When --bin is specified, `cargo-chef` will ignore all members of the workspace
+    /// that are not necessary to successfully compile the specific binary.
     #[clap(long)]
     bin: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,10 +114,8 @@ pub struct Cook {
     /// Cook using `#[no_std]` configuration  (does not affect `proc-macro` crates)
     #[clap(long)]
     no_std: bool,
-    /// Optional: the member in the workspace we wish to compile.
-    /// Note that this is useful in scenarios where we don't copy
-    /// the whole workspace over. Cargo will complain that it can't
-    /// find those members, so this replaces all of the members.
+    /// When --bin is specified, `cargo-chef` will ignore all members of the workspace
+    /// that are not necessary to successfully compile the specific binary.
     #[clap(long)]
     bin: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ pub struct Prepare {
     #[clap(long, default_value = "recipe.json")]
     recipe_path: PathBuf,
 
-    /// Optional: the member in the workspace we wish to compile.
+    /// Optional: the name of the binary we wish to compile.
     /// Note that this is useful in scenarios where we don't copy
     /// the whole workspace over. Cargo will complain that it can't
     /// find those members, so this replaces all of the members.

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn _main() -> Result<(), anyhow::Error> {
             workspace,
             offline,
             no_std,
-            bin: _bin,
+            bin,
         }) => {
             if atty::is(atty::Stream::Stdout) {
                 eprintln!("WARNING stdout appears to be a terminal.");
@@ -211,6 +211,7 @@ fn _main() -> Result<(), anyhow::Error> {
                     workspace,
                     offline,
                     no_std,
+                    bin,
                 })
                 .context("Failed to cook recipe.")?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,13 @@ pub struct Prepare {
     /// It defaults to "recipe.json".
     #[clap(long, default_value = "recipe.json")]
     recipe_path: PathBuf,
+
+    /// Optional: the member in the workspace we wish to compile.
+    /// Note that this is useful in scenarios where we don't copy
+    /// the whole workspace over. Cargo will complain that it can't
+    /// find those members, so this replaces all of the members.
+    #[clap(long)]
+    member: Option<String>,
 }
 
 #[derive(Parser)]
@@ -204,8 +211,12 @@ fn _main() -> Result<(), anyhow::Error> {
                 })
                 .context("Failed to cook recipe.")?;
         }
-        Command::Prepare(Prepare { recipe_path }) => {
-            let recipe = Recipe::prepare(current_directory).context("Failed to compute recipe")?;
+        Command::Prepare(Prepare {
+            recipe_path,
+            member,
+        }) => {
+            let recipe =
+                Recipe::prepare(current_directory, member).context("Failed to compute recipe")?;
             let serialized =
                 serde_json::to_string(&recipe).context("Failed to serialize recipe.")?;
             fs::write(recipe_path, serialized).context("Failed to save recipe to 'recipe.json'")?;

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -30,6 +30,7 @@ pub struct CookArgs {
     pub workspace: bool,
     pub offline: bool,
     pub no_std: bool,
+    pub bin: Option<String>,
 }
 
 impl Recipe {
@@ -80,7 +81,8 @@ fn build_dependencies(args: &CookArgs) {
         package,
         workspace,
         offline,
-        ..
+        bin,
+        no_std: _no_std,
     } = args;
     let mut command = Command::new("cargo");
     let command_with_args = if *check {
@@ -121,6 +123,9 @@ fn build_dependencies(args: &CookArgs) {
     }
     if let Some(package) = package {
         command_with_args.arg("--package").arg(package);
+    }
+    if let Some(binary_target) = bin {
+        command_with_args.arg("--bin").arg(binary_target);
     }
     if *workspace {
         command_with_args.arg("--workspace");

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -33,8 +33,8 @@ pub struct CookArgs {
 }
 
 impl Recipe {
-    pub fn prepare(base_path: PathBuf) -> Result<Self, anyhow::Error> {
-        let skeleton = Skeleton::derive(&base_path)?;
+    pub fn prepare(base_path: PathBuf, member: Option<String>) -> Result<Self, anyhow::Error> {
+        let skeleton = Skeleton::derive(&base_path, member)?;
         Ok(Recipe { skeleton })
     }
 

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -316,7 +316,10 @@ fn replace_members_with_specific<P: AsRef<Path>>(
     let top_level_path = base_path.as_ref().join("Cargo.toml");
     let contents = fs::read_to_string(&top_level_path)?;
     let mut top_level: toml::Value = toml::from_str(&contents)?;
-    if let Some(members) = top_level.get_mut("workspace.members") {
+    if let Some(members) = top_level
+        .get_mut("workspace")
+        .and_then(|workspace| workspace.get_mut("members"))
+    {
         let members = members.as_array_mut().unwrap();
         *members = vec![toml::Value::String(member)];
     }

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -35,10 +35,11 @@ impl Skeleton {
     ) -> Result<Self, anyhow::Error> {
         // Read relevant files from the filesystem
         let config_file = read::config(&base_path)?;
-        if let Some(member) = member {
-            replace_members_with_specific(&base_path, member)?;
-        }
         let mut manifests = read::manifests(&base_path, config_file.as_deref())?;
+        if let Some(member) = member {
+            ignore_all_members_except(&mut manifests, member)?;
+        }
+
         let mut lock_file = read::lockfile(&base_path)?;
 
         version_masking::mask_local_crate_versions(&mut manifests, &mut lock_file);
@@ -309,20 +310,20 @@ fn serialize_manifests(manifests: Vec<ParsedManifest>) -> Result<Vec<Manifest>, 
 
 /// If the top-level `Cargo.toml` has a `members` field, replace it with
 /// a list consisting of just the specified member.
-fn replace_members_with_specific<P: AsRef<Path>>(
-    base_path: P,
+fn ignore_all_members_except(
+    manifests: &mut [ParsedManifest],
     member: String,
 ) -> Result<(), anyhow::Error> {
-    let top_level_path = base_path.as_ref().join("Cargo.toml");
-    let contents = fs::read_to_string(&top_level_path)?;
-    let mut top_level: toml::Value = toml::from_str(&contents)?;
-    if let Some(members) = top_level
-        .get_mut("workspace")
+    let workspace_toml = manifests
+        .iter_mut()
+        .find(|manifest| manifest.relative_path == std::path::PathBuf::from("Cargo.toml"));
+
+    if let Some(members) = workspace_toml
+        .and_then(|toml| toml.contents.get_mut("workspace"))
         .and_then(|workspace| workspace.get_mut("members"))
     {
         let members = members.as_array_mut().unwrap();
         *members = vec![toml::Value::String(member)];
-        fs::write(top_level_path, toml::to_string(&top_level)?)?;
     }
 
     Ok(())

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -316,7 +316,7 @@ fn replace_members_with_specific<P: AsRef<Path>>(
     let top_level_path = base_path.as_ref().join("Cargo.toml");
     let contents = fs::read_to_string(&top_level_path)?;
     let mut top_level: toml::Value = toml::from_str(&contents)?;
-    if let Some(members) = top_level.get_mut("members") {
+    if let Some(members) = top_level.get_mut("workspace.members") {
         let members = members.as_array_mut().unwrap();
         *members = vec![toml::Value::String(member)];
     }

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -37,7 +37,7 @@ impl Skeleton {
         let config_file = read::config(&base_path)?;
         let mut manifests = read::manifests(&base_path, config_file.as_deref())?;
         if let Some(member) = member {
-            ignore_all_members_except(&mut manifests, member)?;
+            ignore_all_members_except(&mut manifests, member);
         }
 
         let mut lock_file = read::lockfile(&base_path)?;
@@ -310,10 +310,7 @@ fn serialize_manifests(manifests: Vec<ParsedManifest>) -> Result<Vec<Manifest>, 
 
 /// If the top-level `Cargo.toml` has a `members` field, replace it with
 /// a list consisting of just the specified member.
-fn ignore_all_members_except(
-    manifests: &mut [ParsedManifest],
-    member: String,
-) -> Result<(), anyhow::Error> {
+fn ignore_all_members_except(manifests: &mut [ParsedManifest], member: String) {
     let workspace_toml = manifests
         .iter_mut()
         .find(|manifest| manifest.relative_path == std::path::PathBuf::from("Cargo.toml"));
@@ -322,11 +319,6 @@ fn ignore_all_members_except(
         .and_then(|toml| toml.contents.get_mut("workspace"))
         .and_then(|workspace| workspace.get_mut("members"))
     {
-        let members = members.as_array_mut().ok_or_else(|| {
-            anyhow::anyhow!("Could not remove uneccessary members from workspace Cargo.toml")
-        })?;
-        *members = vec![toml::Value::String(member)];
+        *members = toml::Value::Array(vec![toml::Value::String(member)]);
     }
-
-    Ok(())
 }

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -322,7 +322,9 @@ fn ignore_all_members_except(
         .and_then(|toml| toml.contents.get_mut("workspace"))
         .and_then(|workspace| workspace.get_mut("members"))
     {
-        let members = members.as_array_mut().unwrap();
+        let members = members.as_array_mut().ok_or_else(|| {
+            anyhow::anyhow!("Could not remove uneccessary members from workspace Cargo.toml")
+        })?;
         *members = vec![toml::Value::String(member)];
     }
 

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -322,8 +322,8 @@ fn replace_members_with_specific<P: AsRef<Path>>(
     {
         let members = members.as_array_mut().unwrap();
         *members = vec![toml::Value::String(member)];
+        fs::write(top_level_path, toml::to_string(&top_level)?)?;
     }
-    fs::write(top_level_path, toml::to_string(&top_level)?)?;
 
     Ok(())
 }

--- a/tests/recipe.rs
+++ b/tests/recipe.rs
@@ -14,7 +14,7 @@ fn quick_recipe(content: &str) -> Recipe {
         bin_dir.child(filename).touch().unwrap();
         test_dir.child(filename).touch().unwrap();
     }
-    Recipe::prepare(recipe_directory.path().into()).unwrap()
+    Recipe::prepare(recipe_directory.path().into(), None).unwrap()
 }
 
 #[test]

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -932,8 +932,6 @@ members = ["backend"]
 "#;
 
     // Assert:
-    // - that "ci" is not in `members`
-    recipe_directory.child("Cargo.toml").assert(gold);
     // - that "ci" is not in `skeleton`'s manifests
     assert!(skeleton
         .manifests

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -927,11 +927,28 @@ edition = "2018"
     // Act
     let skeleton = Skeleton::derive(recipe_directory.path(), "backend".to_string().into()).unwrap();
 
-    // Assert
-    recipe_directory.child("Cargo.toml").assert(
-        r#"[workspace]
+    let gold = r#"[workspace]
 members = ["backend"]
-"#,
+"#;
+
+    // Assert:
+    // - that "ci" is not in `members`
+    recipe_directory.child("Cargo.toml").assert(gold);
+    // - that "ci" is not in `skeleton`'s manifests
+    assert!(skeleton
+        .manifests
+        .iter()
+        .all(|manifest| !manifest.contents.contains("ci")));
+
+    // - that the root manifest matches the file contents
+    assert!(
+        skeleton
+            .manifests
+            .iter()
+            .find(|manifest| manifest.relative_path == std::path::PathBuf::from("Cargo.toml"))
+            .unwrap()
+            .contents
+            == gold
     );
 }
 

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -892,6 +892,49 @@ description = "sample package representing all of rocket's dependencies""#;
     assert_eq!(1, skeleton.manifests.len());
 }
 
+#[test]
+pub fn specify_member_in_workspace() {
+    // Arrange
+    let workspace_content = r#"
+[workspace]
+
+members = [
+    "backend",
+    "ci",
+]
+    "#;
+
+    let first_content = r#"
+[package]
+name = "backend"
+version = "0.1.0"
+edition = "2018"
+    "#;
+
+    let recipe_directory = TempDir::new().unwrap();
+    let manifest = recipe_directory.child("Cargo.toml");
+    manifest.write_str(workspace_content).unwrap();
+    let backend = recipe_directory.child("backend");
+    backend.create_dir_all().unwrap();
+
+    backend
+        .child("Cargo.toml")
+        .write_str(first_content)
+        .unwrap();
+    backend.child("src").create_dir_all().unwrap();
+    backend.child("src").child("main.rs").touch().unwrap();
+
+    // Act
+    let skeleton = Skeleton::derive(recipe_directory.path(), "backend".to_string().into()).unwrap();
+
+    // Assert
+    recipe_directory.child("Cargo.toml").assert(
+        r#"[workspace]
+members = ["backend"]
+"#,
+    );
+}
+
 fn check(actual: &str, expect: Expect) {
     let actual = actual.to_string();
     expect.assert_eq(&actual);

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -34,7 +34,7 @@ path = "src/main.rs"
         .unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -53,7 +53,7 @@ path = "src/main.rs"
         .assert(predicate::path::exists());
 
     // Act (no_std)
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), true)
@@ -140,7 +140,7 @@ uuid = { version = "=0.8.0", features = ["v4"] }
     project_b.child("src").child("lib.rs").touch().unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -162,7 +162,7 @@ uuid = { version = "=0.8.0", features = ["v4"] }
         .assert("");
 
     // Act (no_std)
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), true)
@@ -229,7 +229,7 @@ harness = false
         .unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -277,7 +277,7 @@ name = "foo"
         .unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -290,7 +290,7 @@ name = "foo"
     cook_directory.child("tests").child("foo.rs").assert("");
 
     // Act (no_std)
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), true)
@@ -349,7 +349,7 @@ name = "foo"
         .unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -365,7 +365,7 @@ name = "foo"
         .assert("fn main() {}");
 
     // Act (no_std)
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), true)
@@ -409,14 +409,14 @@ edition = "2018"
     bin_dir.child("f.rs").touch().unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
 
     // What we're testing is that auto-directories come back in the same order.
     // Since it's possible that the directories just happen to come back in the
     // same order randomly, we'll run this a few times to increase the
     // likelihood of triggering the problem if it exists.
     for _ in 0..5 {
-        let skeleton2 = Skeleton::derive(recipe_directory.path()).unwrap();
+        let skeleton2 = Skeleton::derive(recipe_directory.path(), None).unwrap();
         assert_eq!(
             skeleton, skeleton2,
             "Skeletons of equal directories are not equal. Check [[bin]] ordering in manifest?"
@@ -453,7 +453,7 @@ pub fn config_toml() {
         .unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -502,7 +502,7 @@ pub fn version() {
         .unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -555,7 +555,7 @@ version = "1.2.3"
         .unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -671,7 +671,7 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
     project_b.child("src").child("lib.rs").touch().unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
     let cook_directory = TempDir::new().unwrap();
     skeleton
         .build_minimum_project(cook_directory.path(), false)
@@ -886,7 +886,7 @@ description = "sample package representing all of rocket's dependencies""#;
         .unwrap();
 
     // Act
-    let skeleton = Skeleton::derive(recipe_directory.path()).unwrap();
+    let skeleton = Skeleton::derive(recipe_directory.path(), None).unwrap();
 
     // Assert
     assert_eq!(1, skeleton.manifests.len());


### PR DESCRIPTION
If specified, and if the top-level cargo.toml
has a members list, replace the list with
only the specified member. 

This is an attempt to address https://github.com/LukeMathWalker/cargo-chef/issues/125. 
If you have feedback on naming or code structure (I feel a little weird placing this function in `mod.rs`),
please let me know! I am happy to make those changes.

I have verified that this works for https://github.com/prestontw/cargo-chef-workspace-experiment