### PR TITLE
Add support for --profile flag

### DIFF
--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -55,10 +55,11 @@ impl Recipe {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum OptimisationProfile {
     Release,
     Debug,
+    Other(String),
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -90,6 +91,8 @@ fn build_dependencies(args: &CookArgs) {
     };
     if profile == &OptimisationProfile::Release {
         command_with_args.arg("--release");
+    } else if let OptimisationProfile::Other(custom_profile) = profile {
+        command_with_args.arg("--profile").arg(custom_profile);
     }
     if default_features == &DefaultFeatures::Disabled {
         command_with_args.arg("--no-default-features");

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -242,6 +242,7 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
         let target_directory = match profile {
             OptimisationProfile::Release => target_dir.join("release"),
             OptimisationProfile::Debug => target_dir.join("debug"),
+            OptimisationProfile::Other(custom_profile) => target_dir.join(custom_profile),
         };
 
         for manifest in &self.manifests {


### PR DESCRIPTION
Fixes #109. This PR adds support for [profile flag](https://doc.rust-lang.org/cargo/reference/profiles.html), mimicking the same interface of `cargo build`