### PR TITLE
fix: deal with bins that don't have `path`

### DIFF
--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -102,7 +102,10 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
             // Create dummy entrypoint files for all binaries
             for bin in &parsed_manifest.bin.unwrap_or_default() {
                 // Relative to the manifest path
-                let binary_relative_path = bin.path.as_deref().unwrap_or("src/main.rs");
+                let binary_relative_path = bin.path.to_owned().unwrap_or_else(|| match &bin.name {
+                    Some(name) => format!("src/bin/{}.rs", name),
+                    None => "src/main.rs".to_owned(),
+                });
                 let binary_path = parent_directory.join(binary_relative_path);
                 if let Some(parent_directory) = binary_path.parent() {
                     fs::create_dir_all(parent_directory)?;

--- a/src/skeleton/read.rs
+++ b/src/skeleton/read.rs
@@ -70,12 +70,12 @@ pub(super) fn manifests<P: AsRef<Path>>(
                     bins.sort_by(|bin_a, bin_b| {
                         let bin_a_path = bin_a
                             .as_table()
-                            .and_then(|table| table.get("path"))
+                            .and_then(|table| table.get("path").or_else(|| table.get("name")))
                             .and_then(|path| path.as_str())
                             .unwrap();
                         let bin_b_path = bin_b
                             .as_table()
-                            .and_then(|table| table.get("path"))
+                            .and_then(|table| table.get("path").or_else(|| table.get("name")))
                             .and_then(|path| path.as_str())
                             .unwrap();
                         bin_a_path.cmp(bin_b_path)


### PR DESCRIPTION
Implicitly Cargo could find them as `src/bin/{name}.rs`