### PR TITLE
feat: flag dont_mask_local_crate_versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,11 @@ pub struct Prepare {
     /// It defaults to "recipe.json".
     #[clap(long, default_value = "recipe.json")]
     recipe_path: PathBuf,
+
+    /// Disables masking local crate versions in the recipe. You can try this
+    /// flag if some of your local dependencies don't resolve.
+    #[clap(long)]
+    dont_mask_local_crate_versions: bool,
 }
 
 #[derive(Parser)]
@@ -204,8 +209,8 @@ fn _main() -> Result<(), anyhow::Error> {
                 })
                 .context("Failed to cook recipe.")?;
         }
-        Command::Prepare(Prepare { recipe_path }) => {
-            let recipe = Recipe::prepare(current_directory).context("Failed to compute recipe")?;
+        Command::Prepare(Prepare { recipe_path, dont_mask_local_crate_versions }) => {
+            let recipe = Recipe::prepare(current_directory, !dont_mask_local_crate_versions).context("Failed to compute recipe")?;
             let serialized =
                 serde_json::to_string(&recipe).context("Failed to serialize recipe.")?;
             fs::write(recipe_path, serialized).context("Failed to save recipe to 'recipe.json'")?;

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -33,8 +33,8 @@ pub struct CookArgs {
 }
 
 impl Recipe {
-    pub fn prepare(base_path: PathBuf) -> Result<Self, anyhow::Error> {
-        let skeleton = Skeleton::derive(&base_path)?;
+    pub fn prepare(base_path: PathBuf, enable_local_crate_version_masking: bool) -> Result<Self, anyhow::Error> {
+        let skeleton = Skeleton::derive(&base_path, enable_local_crate_version_masking)?;
         Ok(Recipe { skeleton })
     }
 

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -29,13 +29,15 @@ pub(in crate::skeleton) struct ParsedManifest {
 
 impl Skeleton {
     /// Find all Cargo.toml files in `base_path` by traversing sub-directories recursively.
-    pub fn derive<P: AsRef<Path>>(base_path: P) -> Result<Self, anyhow::Error> {
+    pub fn derive<P: AsRef<Path>>(base_path: P, enable_local_crate_version_masking: bool) -> Result<Self, anyhow::Error> {
         // Read relevant files from the filesystem
         let config_file = read::config(&base_path)?;
         let mut manifests = read::manifests(&base_path, config_file.as_deref())?;
         let mut lock_file = read::lockfile(&base_path)?;
 
-        version_masking::mask_local_crate_versions(&mut manifests, &mut lock_file);
+        if enable_local_crate_version_masking {
+            version_masking::mask_local_crate_versions(&mut manifests, &mut lock_file);
+        }
 
         let lock_file = lock_file.map(|l| toml::to_string(&l)).transpose()?;
 


### PR DESCRIPTION
I had to create this for my project which has a local version of some of the dependencies (e.g. I forked `rust-decimal` which is required by some other dependencies). I believe the logic behind masking local crate version is that local crates wouldn't be referenced by other dependencies but for my case I had to disable masking for it to build.

Comments / modifications welcome