### PR TITLE
Automatically detect which Rust toolchain should be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ If you want to build in `--release` mode:
 cargo chef cook --release --recipe-path recipe.json
 ```
 
-You can leverage it in a Dockerfile:
+You can also choose to override which Rust toolchain should be used. E.g., to force the `nightly` toolchain:
+
+```bash
+cargo +nightly chef cook --recipe-path recipe.json
+```
+
+`cargo-chef` is designed to be leveraged in Dockerfiles:
 
 ```dockerfile
 FROM lukemathwalker/cargo-chef:latest-rust-1.56.0 AS chef

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,13 +173,14 @@ fn _main() -> Result<(), anyhow::Error> {
                 }
             });
 
-            let unstable_features: Option<HashSet<String>> = unstable_features.and_then(|unstable_features| {
-                if unstable_features.is_empty() {
-                    None
-                } else {
-                    Some(unstable_features.into_iter().collect())
-                }
-            });
+            let unstable_features: Option<HashSet<String>> =
+                unstable_features.and_then(|unstable_features| {
+                    if unstable_features.is_empty() {
+                        None
+                    } else {
+                        Some(unstable_features.into_iter().collect())
+                    }
+                });
 
             let profile = match (release, profile) {
                 (false, None) =>  OptimisationProfile::Debug,

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -83,7 +83,8 @@ fn build_dependencies(args: &CookArgs) {
         offline,
         ..
     } = args;
-    let mut command = Command::new("cargo");
+    let cargo_path = std::env::var("CARGO").expect("The `CARGO` environment variable was not set. This is unexpected: it should always be provided by `cargo` when invoking a custom sub-command, allowing `cargo-chef` to correctly detect which toolchain should be used. Please file a bug.");
+    let mut command = Command::new(cargo_path);
     let command_with_args = if *check {
         command.arg("check")
     } else {


### PR DESCRIPTION
Fixes #136 