### PR TITLE
ci: Fix failing builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,5 +4,5 @@ ARG CHEF_TAG
 
 # Install musl-dev on Alpine to avoid error "ld: cannot find crti.o: No such file or directory"
 RUN ((cat /etc/os-release | grep ID | grep alpine) && apk add --no-cache musl-dev || true) \
-    && CARGO_NET_GIT_FETCH_WITH_CLI=true cargo install cargo-chef --locked --version $CHEF_TAG \
+    && cargo install cargo-chef --locked --version $CHEF_TAG \
     && rm -rf $CARGO_HOME/registry/


### PR DESCRIPTION
This error seems to have been introduced by the environment variable added in https://github.com/LukeMathWalker/cargo-chef/commit/f57e866a546a1cbddb08091381cf09aa50b65aaf.

Perhaps we can wait with extra speed until sparse index is in stable..?