### PR TITLE
feat: Add --timings argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,9 @@ pub struct Cook {
     /// Build offline.
     #[clap(long)]
     offline: bool,
+    /// Report build timings.
+    #[clap(long)]
+    timings: bool,
     /// Cook using `#[no_std]` configuration  (does not affect `proc-macro` crates)
     #[clap(long)]
     no_std: bool,
@@ -152,6 +155,7 @@ fn _main() -> Result<(), anyhow::Error> {
             package,
             workspace,
             offline,
+            timings,
             no_std,
             bin,
         }) => {
@@ -229,6 +233,7 @@ fn _main() -> Result<(), anyhow::Error> {
                     package,
                     workspace,
                     offline,
+                    timings,
                     no_std,
                     bin,
                 })

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -30,6 +30,7 @@ pub struct CookArgs {
     pub package: Option<String>,
     pub workspace: bool,
     pub offline: bool,
+    pub timings: bool,
     pub no_std: bool,
     pub bin: Option<String>,
 }
@@ -84,6 +85,7 @@ fn build_dependencies(args: &CookArgs) {
         package,
         workspace,
         offline,
+        timings,
         bin,
         no_std: _no_std,
     } = args;
@@ -143,6 +145,9 @@ fn build_dependencies(args: &CookArgs) {
     }
     if *offline {
         command_with_args.arg("--offline");
+    }
+    if *timings {
+        command_with_args.arg("--timings");
     }
 
     execute_command(command_with_args);


### PR DESCRIPTION
Pass through the `--timings` flag to `cargo` to be able to diagnose build times of dependencies.