### PR TITLE
Add support for `cargo-zigbuild`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,10 @@ pub struct Cook {
     /// that are not necessary to successfully compile the specific binary.
     #[clap(long)]
     bin: Option<String>,
+    /// Run `cargo zigbuild` instead of `cargo build`. You need to install
+    /// the `cargo-zigbuild` crate and the Zig compiler toolchain separately
+    #[clap(long)]
+    zigbuild: bool,
 }
 
 fn _main() -> Result<(), anyhow::Error> {
@@ -158,6 +162,7 @@ fn _main() -> Result<(), anyhow::Error> {
             timings,
             no_std,
             bin,
+            zigbuild,
         }) => {
             if atty::is(atty::Stream::Stdout) {
                 eprintln!("WARNING stdout appears to be a terminal.");
@@ -236,6 +241,7 @@ fn _main() -> Result<(), anyhow::Error> {
                     timings,
                     no_std,
                     bin,
+                    zigbuild,
                 })
                 .context("Failed to cook recipe.")?;
         }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -33,6 +33,7 @@ pub struct CookArgs {
     pub timings: bool,
     pub no_std: bool,
     pub bin: Option<String>,
+    pub zigbuild: bool,
 }
 
 impl Recipe {
@@ -88,13 +89,18 @@ fn build_dependencies(args: &CookArgs) {
         timings,
         bin,
         no_std: _no_std,
+        zigbuild,
     } = args;
     let cargo_path = std::env::var("CARGO").expect("The `CARGO` environment variable was not set. This is unexpected: it should always be provided by `cargo` when invoking a custom sub-command, allowing `cargo-chef` to correctly detect which toolchain should be used. Please file a bug.");
     let mut command = Command::new(cargo_path);
     let command_with_args = if *check {
         command.arg("check")
     } else {
-        command.arg("build")
+        if *zigbuild {
+            command.arg("zigbuild")
+        } else {
+            command.arg("build")
+        }
     };
     if profile == &OptimisationProfile::Release {
         command_with_args.arg("--release");


### PR DESCRIPTION
Adds support for [`cargo-zigbuild`](https://github.com/messense/cargo-zigbuild). This allows for better UX surrounding cross-platform compilation.

Users still need to install cargo-zigbuild manually and also install the Zig toolchain, though. I suppose it could be installed by chef too, but I'm not sure if that's the expected/desired behaviour.

Related:
 - https://github.com/LukeMathWalker/cargo-chef/issues/135