### PR TITLE
Fix Docker Tag in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cargo +nightly chef cook --recipe-path recipe.json
 `cargo-chef` is designed to be leveraged in Dockerfiles:
 
 ```dockerfile
-FROM lukemathwalker/cargo-chef:latest-rust-1.56.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR app
 
 FROM chef AS planner
@@ -137,7 +137,7 @@ You can find [all the available tags on Dockerhub](https://hub.docker.com/r/luke
 If you do not want to use the `lukemathwalker/cargo-chef` image, you can simply install the CLI within the Dockerfile:
 
 ```dockerfile
-FROM rust:1.56.0 AS chef 
+FROM rust:1 AS chef 
 # We only pay the installation cost once, 
 # it will be cached from the second build onwards
 RUN cargo install cargo-chef 


### PR DESCRIPTION
Readme refers to an old version of Rust. [Rust image](https://hub.docker.com/_/rust) already has `1` tag that refers to the latest stable version of 1.* for Rust or [cargo-chef image](https://hub.docker.com/r/lukemathwalker/cargo-chef/) already has `latest-rust-1` tag that refers to the same.

Some dependencies might require latest stable to work. In #160, `clap` 4.15.0 was a dependency, which was only available on the latest version of Rust. So, the build failed due to readme containing an old version of Rust.

Thus, it is sensible to change these lines in readme in order to refer to the latest stable version of Rust.