### PR TITLE
Extend to enable using for clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod recipe;
 mod skeleton;
 
-pub use recipe::{CookArgs, DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
+pub use recipe::{CommandArg,CookArgs, DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
 pub use skeleton::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context};
-use chef::{CookArgs, DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
+use chef::{CommandArg, CookArgs, DefaultFeatures, OptimisationProfile, Recipe, TargetArgs};
 use clap::crate_version;
 use clap::Parser;
 use fs_err as fs;
@@ -75,6 +75,9 @@ pub struct Cook {
     /// Run `cargo check` instead of `cargo build`. Primarily useful for speeding up your CI pipeline.
     #[clap(long)]
     check: bool,
+    /// Run `cargo clippy` instead of `cargo build`. Primarily useful for speeding up your CI pipeline. Requires clippy to be installed.
+    #[clap(long)]
+    clippy: bool,
     /// Build for the target triple.
     #[clap(long)]
     target: Option<String>,
@@ -142,6 +145,7 @@ fn _main() -> Result<(), anyhow::Error> {
             profile,
             release,
             check,
+            clippy,
             target,
             no_default_features,
             features,
@@ -202,6 +206,12 @@ fn _main() -> Result<(), anyhow::Error> {
                 (false, Some(custom_profile)) => OptimisationProfile::Other(custom_profile),
                 (true, Some(_)) => Err(anyhow!("You specified both --release and --profile arguments. Please remove one of them, or both"))?
             };
+            let command = match (check, clippy) {
+                (true, true) => Err(anyhow!("You specified both `clippy` and `check` arguments. Please remove one of them, or both"))?,
+                (true, false) => CommandArg::Check,
+                (false, true) => CommandArg::Clippy,
+                (false, false) => CommandArg::Build,
+            };
 
             let default_features = if no_default_features {
                 DefaultFeatures::Disabled
@@ -222,7 +232,7 @@ fn _main() -> Result<(), anyhow::Error> {
             recipe
                 .cook(CookArgs {
                     profile,
-                    check,
+                    command,
                     default_features,
                     features,
                     unstable_features,

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -17,9 +17,15 @@ pub struct TargetArgs {
     pub all_targets: bool,
 }
 
+pub enum CommandArg {
+    Build,
+    Check,
+    Clippy,
+}
+
 pub struct CookArgs {
     pub profile: OptimisationProfile,
-    pub check: bool,
+    pub command: CommandArg,
     pub default_features: DefaultFeatures,
     pub features: Option<HashSet<String>>,
     pub unstable_features: Option<HashSet<String>>,
@@ -74,7 +80,7 @@ pub enum DefaultFeatures {
 fn build_dependencies(args: &CookArgs) {
     let CookArgs {
         profile,
-        check,
+        command: command_arg,
         default_features,
         features,
         unstable_features,
@@ -91,10 +97,10 @@ fn build_dependencies(args: &CookArgs) {
     } = args;
     let cargo_path = std::env::var("CARGO").expect("The `CARGO` environment variable was not set. This is unexpected: it should always be provided by `cargo` when invoking a custom sub-command, allowing `cargo-chef` to correctly detect which toolchain should be used. Please file a bug.");
     let mut command = Command::new(cargo_path);
-    let command_with_args = if *check {
-        command.arg("check")
-    } else {
-        command.arg("build")
+    let command_with_args = match command_arg {
+        CommandArg::Build => command.arg("build"),
+        CommandArg::Check => command.arg("check"),
+        CommandArg::Clippy => command.arg("clippy"),
     };
     if profile == &OptimisationProfile::Release {
         command_with_args.arg("--release");


### PR DESCRIPTION
Basically like https://github.com/LukeMathWalker/cargo-chef/pull/72, except for `clippy`.

Also extended a bit the config to allow better configuration of commands (e.g. for https://github.com/LukeMathWalker/cargo-chef/pull/158)