### PR TITLE
Initial work to support Cross Workspace Dependencies (would fix #4)

### DIFF
--- a/src/skeleton/read.rs
+++ b/src/skeleton/read.rs
@@ -1,9 +1,10 @@
 //! Logic to read all the files required to build a caching layer for a project.
 use super::ParsedManifest;
+use cargo_manifest::Manifest;
 use cargo_metadata::Metadata;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 pub(super) fn config<P: AsRef<Path>>(base_path: &P) -> Result<Option<String>, anyhow::Error> {
@@ -39,63 +40,88 @@ pub(super) fn manifests<P: AsRef<Path>>(
     base_path: &P,
     metadata: Metadata,
 ) -> Result<Vec<ParsedManifest>, anyhow::Error> {
-    let manifest_paths = metadata
-        .workspace_packages()
-        .iter()
-        .map(|package| package.manifest_path.clone().into_std_path_buf())
-        .chain(
-            metadata
-                .root_package()
-                .map(|p| p.clone().manifest_path.into_std_path_buf())
-                .or_else(|| Some(base_path.as_ref().join("Cargo.toml"))),
-        )
-        .collect::<BTreeSet<_>>();
+    fn try_read_manifest(path: &Path) -> anyhow::Result<Manifest> {
+        let contents: String = fs::read_to_string(path)?;
 
-    let mut manifests = vec![];
-    for absolute_path in manifest_paths {
-        let contents = fs::read_to_string(&absolute_path)?;
-
-        let mut parsed = cargo_manifest::Manifest::from_str(&contents)?;
-        // Required to detect bin/libs when the related section is omitted from the manifest
-        parsed.complete_from_path(&absolute_path)?;
-
-        let mut intermediate = toml::Value::try_from(parsed)?;
-
-        // Specifically, toml gives no guarantees to the ordering of the auto binaries
-        // in its results. We will manually sort these to ensure that the output
-        // manifest will match.
-        let bins = intermediate
-            .get_mut("bin")
-            .and_then(|bins| bins.as_array_mut());
-        if let Some(bins) = bins {
-            bins.sort_by(|bin_a, bin_b| {
-                let bin_a_path = bin_a
-                    .as_table()
-                    .and_then(|table| table.get("path").or_else(|| table.get("name")))
-                    .and_then(|path| path.as_str())
-                    .unwrap();
-                let bin_b_path = bin_b
-                    .as_table()
-                    .and_then(|table| table.get("path").or_else(|| table.get("name")))
-                    .and_then(|path| path.as_str())
-                    .unwrap();
-                bin_a_path.cmp(bin_b_path)
-            });
-        }
-
-        let relative_path = pathdiff::diff_paths(&absolute_path, base_path).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Failed to compute relative path of manifest {:?}",
-                &absolute_path
-            )
-        })?;
-        manifests.push(ParsedManifest {
-            relative_path,
-            contents: intermediate,
-        });
+        Ok(cargo_manifest::Manifest::from_str(&contents)?)
     }
 
-    Ok(manifests)
+    let mut manifest_paths = metadata
+        .packages
+        .iter()
+        .filter_map(|p| {
+            if p.source.is_none() {
+                Some(p.manifest_path.to_path_buf())
+            } else {
+                None
+            }
+        })
+        .collect::<BTreeSet<_>>();
+    manifest_paths.insert(metadata.workspace_root.join("Cargo.toml"));
+
+    let mut manifests = BTreeMap::<PathBuf, Manifest>::new();
+    for absolute_path in manifest_paths {
+        let parsed = try_read_manifest(absolute_path.as_std_path())?;
+
+        // it's possible that a path dependency could reference a different Workspace Root
+        if let Some(workspace) = parsed.package.as_ref().and_then(|p| p.workspace.as_ref()) {
+            let workspace_path = absolute_path
+                .parent()
+                .ok_or_else(|| anyhow::anyhow!("Unable to get parent of {}", absolute_path))?
+                .join(workspace)
+                .join("Cargo.toml")
+                .canonicalize()?;
+            if !manifests.contains_key(&workspace_path) {
+                manifests.insert(workspace_path.clone(), try_read_manifest(&workspace_path)?);
+            }
+        }
+
+        manifests.insert(absolute_path.into_std_path_buf(), parsed);
+    }
+
+    manifests
+        .into_iter()
+        .map(|(absolute_path, mut parsed)| {
+            // Required to detect bin/libs when the related section is omitted from the manifest
+            parsed.complete_from_path(&absolute_path)?;
+
+            let mut intermediate = toml::Value::try_from(parsed)?;
+
+            // Specifically, toml gives no guarantees to the ordering of the auto binaries
+            // in its results. We will manually sort these to ensure that the output
+            // manifest will match.
+            let bins = intermediate
+                .get_mut("bin")
+                .and_then(|bins| bins.as_array_mut());
+            if let Some(bins) = bins {
+                bins.sort_by(|bin_a, bin_b| {
+                    let bin_a_path = bin_a
+                        .as_table()
+                        .and_then(|table| table.get("path").or_else(|| table.get("name")))
+                        .and_then(|path| path.as_str())
+                        .unwrap();
+                    let bin_b_path = bin_b
+                        .as_table()
+                        .and_then(|table| table.get("path").or_else(|| table.get("name")))
+                        .and_then(|path| path.as_str())
+                        .unwrap();
+                    bin_a_path.cmp(bin_b_path)
+                });
+            }
+
+            let relative_path =
+                pathdiff::diff_paths(&absolute_path, base_path).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Failed to compute relative path of manifest {:?}",
+                        &absolute_path
+                    )
+                })?;
+            Ok(ParsedManifest {
+                relative_path,
+                contents: intermediate,
+            })
+        })
+        .collect()
 }
 
 pub(super) fn lockfile<P: AsRef<Path>>(


### PR DESCRIPTION
- A Breadth First Search finds all path dependencies & adds any necessary workspace manifests.
- Relies on "manifest.package.workspace" to traverse through to workspace manifests

- Still rough in places, some polishing to come, however this has successfully run against a simple example!

*Issue #, if available: 
https://github.com/LukeMathWalker/cargo-chef/issues/4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
