### PR TITLE
Support for custom target files

### DIFF
--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -270,8 +270,6 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
             .map(|path| path.join(&profile))
             .collect();
 
-        println!("target_directories: {:?}", target_directories);
-
         for manifest in &self.manifests {
             let parsed_manifest =
                 cargo_manifest::Manifest::from_slice(manifest.contents.as_bytes())?;

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -322,7 +322,6 @@ fn target_str(target: &String) -> &str {
     target.as_str().trim_end_matches(".json")
 }
 
-
 fn serialize_manifests(manifests: Vec<ParsedManifest>) -> Result<Vec<Manifest>, anyhow::Error> {
     let mut serialised_manifests = vec![];
     for manifest in manifests {

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -260,12 +260,17 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
             .map_or(vec![target_dir.clone()], |targets| {
                 targets
                     .iter()
-                    .map(|target| target_dir.join(target.as_str()))
+                    .map(|target| {
+                        let target_str = target.as_str().trim_end_matches(".json");
+                        target_dir.join(target_str)
+                    })
                     .collect()
             })
             .iter()
             .map(|path| path.join(&profile))
             .collect();
+
+        println!("target_directories: {:?}", target_directories);
 
         for manifest in &self.manifests {
             let parsed_manifest =

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -260,10 +260,7 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
             .map_or(vec![target_dir.clone()], |targets| {
                 targets
                     .iter()
-                    .map(|target| {
-                        let target_str = target.as_str().trim_end_matches(".json");
-                        target_dir.join(target_str)
-                    })
+                    .map(|target| target_dir.join(target_str(target)))
                     .collect()
             })
             .iter()
@@ -316,6 +313,15 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
         Ok(())
     }
 }
+
+/// If a custom target spec file is used,
+/// (Part of the unstable cargo feature 'build-std'; c.f. https://doc.rust-lang.org/rustc/targets/custom.html )
+/// the `--target` flag refers to a `.json` file in the current directory.
+/// In this case, the actual name of the target is the value of `--target` without the `.json` suffix.
+fn target_str(target: &String) -> &str {
+    target.as_str().trim_end_matches(".json")
+}
+
 
 fn serialize_manifests(manifests: Vec<ParsedManifest>) -> Result<Vec<Manifest>, anyhow::Error> {
     let mut serialised_manifests = vec![];

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -318,8 +318,8 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
 /// (Part of the unstable cargo feature 'build-std'; c.f. https://doc.rust-lang.org/rustc/targets/custom.html )
 /// the `--target` flag refers to a `.json` file in the current directory.
 /// In this case, the actual name of the target is the value of `--target` without the `.json` suffix.
-fn target_str(target: &String) -> &str {
-    target.as_str().trim_end_matches(".json")
+fn target_str(target: &str) -> &str {
+    target.trim_end_matches(".json")
 }
 
 fn serialize_manifests(manifests: Vec<ParsedManifest>) -> Result<Vec<Manifest>, anyhow::Error> {


### PR DESCRIPTION
Fixes #177 

Changes:
- Support `--target=target-name.json` to be passed to `cargo chef`, by fixing the target location that is used during dummy cleanup in this case.