### PR TITLE
ci: Fix failing builds (again)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 ARG BASE_IMAGE=rust
 FROM $BASE_IMAGE
 ARG CHEF_TAG
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # Install musl-dev on Alpine to avoid error "ld: cannot find crti.o: No such file or directory"
 RUN ((cat /etc/os-release | grep ID | grep alpine) && apk add --no-cache musl-dev || true) \


### PR DESCRIPTION
Fixes #185

*Description of changes:*
Remove environment variable CARGO_NET_GIT_FETCH_WITH_CLI=true. [Gets rid of](https://github.com/jacobsvante/cargo-chef/actions/runs/4135633866/jobs/7148369885) the `could not find cargo-chef in registry crates-io with version =X.X.X` error message that all alpine and some debian docker image builds end up with.

I think this optimization will soon be completely unnecessary anyway, considering that [sparse-registry will be stabilized in the next rust release](https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html).

(Fun side note is that this is exactly the same PR I did [half a year ago](https://github.com/LukeMathWalker/cargo-chef/pull/144).)