### PR TITLE
chore: Use sparse protocol to speed up builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=rust
 FROM $BASE_IMAGE
 ARG CHEF_TAG
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 # Install musl-dev on Alpine to avoid error "ld: cannot find crti.o: No such file or directory"
 RUN ((cat /etc/os-release | grep ID | grep alpine) && apk add --no-cache musl-dev || true) \


### PR DESCRIPTION
Should work for Rust 1.68 and upwards.

For more information, please see https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html.

Rust 1.68 is due to be released today. Once the Docker Hub tags for 1.68 exists this will be testable.