### PR TITLE
Build linux-gnu binaries on ubuntu 20.04

### DIFF
--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: x86_64-apple-darwin


### PR DESCRIPTION
*Issue #, if available:*
Fixes #188

*Description of changes:*
`ubuntu-latest` recently changed to be 22.04, from 20.04. This broke binaries that were being built being run in older distros (e.g., Debian stable, as is the default for the `rust` docker image). This fixes that by building the binaries against the older glibc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
