### PR TITLE
Use `cargo metadata` to find workspace manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-chef"
 version = "0.1.54"
 dependencies = [
@@ -131,6 +140,7 @@ dependencies = [
  "assert_fs",
  "atty",
  "cargo-manifest",
+ "cargo_metadata",
  "clap",
  "env_logger",
  "expect-test",
@@ -152,6 +162,29 @@ checksum = "9b553708c7ce3d7789774f44389865719c2901afb5e6b3ae8cd1303c95488735"
 dependencies = [
  "serde",
  "toml",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -624,6 +657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +749,26 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cargo-manifest = "0.8"
 fs-err = "2.5.0"
 toml = { version = "0.7", features = ["preserve_order"] }
 expect-test = "1.1.0"
+cargo_metadata = "0.15"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -358,7 +358,7 @@ fn ignore_all_members_except(manifests: &mut Vec<ParsedManifest>, member: String
         *members = toml::Value::Array(vec![toml::Value::String(member.clone())]);
     }
 
-    // Remove manifest(s) with package name equal to `member`
+    // Keep only manifest(s) with package name equal to `member`
     manifests.retain(|manifest| {
         let package_name = manifest
             .contents

--- a/src/skeleton/read.rs
+++ b/src/skeleton/read.rs
@@ -1,9 +1,9 @@
 //! Logic to read all the files required to build a caching layer for a project.
 use super::ParsedManifest;
-use anyhow::Context;
-use globwalk::{GlobWalkerBuilder, WalkError};
+use cargo_metadata::Metadata;
+use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 pub(super) fn config<P: AsRef<Path>>(base_path: &P) -> Result<Option<String>, anyhow::Error> {
@@ -35,87 +35,63 @@ pub(super) fn config<P: AsRef<Path>>(base_path: &P) -> Result<Option<String>, an
     }
 }
 
-fn vendored_directory(config_contents: Option<&str>) -> Option<String> {
-    let contents = config_contents.and_then(|contents| contents.parse::<toml::Value>().ok())?;
-    let source = contents.get("source")?;
-    let crates_io = source.get("crates-io")?;
-    let vendored_field_suffix = crates_io
-        .get("replace-with")
-        .and_then(|value| value.as_str())?;
-    let vendored_sources = source.get(vendored_field_suffix)?;
-    Some(vendored_sources.get("directory")?.as_str()?.to_owned())
-}
-
 pub(super) fn manifests<P: AsRef<Path>>(
     base_path: &P,
-    config_contents: Option<&str>,
+    metadata: Metadata,
 ) -> Result<Vec<ParsedManifest>, anyhow::Error> {
-    let vendored_path = vendored_directory(config_contents);
-    let builder = if let Some(path) = vendored_path {
-        let exclude_vendored_sources = format!("!{}", path);
-        GlobWalkerBuilder::from_patterns(base_path, &["/**/Cargo.toml", &exclude_vendored_sources])
-    } else {
-        GlobWalkerBuilder::new(base_path, "/**/Cargo.toml")
-    };
-    let walker = builder
-        .build()
-        .context("Failed to scan the files in the current directory.")?;
+    let mut metadata_paths = metadata
+        .workspace_packages()
+        .into_iter()
+        .map(|package| package.manifest_path.clone().into_std_path_buf())
+        .collect::<HashSet<_>>();
+    metadata_paths.insert(base_path.as_ref().join("Cargo.toml"));
+    let mut manifest_paths: Vec<PathBuf> = metadata_paths.into_iter().collect();
+    manifest_paths.sort();
 
     let mut manifests = vec![];
-    for manifest in walker {
-        match manifest {
-            Ok(manifest) => {
-                let absolute_path = manifest.path().to_path_buf();
-                let contents = fs::read_to_string(&absolute_path)?;
+    for absolute_path in manifest_paths {
+        let contents = fs::read_to_string(&absolute_path)?;
 
-                let mut parsed = cargo_manifest::Manifest::from_str(&contents)?;
-                // Required to detect bin/libs when the related section is omitted from the manifest
-                parsed.complete_from_path(&absolute_path)?;
+        let mut parsed = cargo_manifest::Manifest::from_str(&contents)?;
+        // Required to detect bin/libs when the related section is omitted from the manifest
+        parsed.complete_from_path(&absolute_path)?;
 
-                let mut intermediate = toml::Value::try_from(parsed)?;
+        let mut intermediate = toml::Value::try_from(parsed)?;
 
-                // Specifically, toml gives no guarantees to the ordering of the auto binaries
-                // in its results. We will manually sort these to ensure that the output
-                // manifest will match.
-                let bins = intermediate
-                    .get_mut("bin")
-                    .and_then(|bins| bins.as_array_mut());
-                if let Some(bins) = bins {
-                    bins.sort_by(|bin_a, bin_b| {
-                        let bin_a_path = bin_a
-                            .as_table()
-                            .and_then(|table| table.get("path").or_else(|| table.get("name")))
-                            .and_then(|path| path.as_str())
-                            .unwrap();
-                        let bin_b_path = bin_b
-                            .as_table()
-                            .and_then(|table| table.get("path").or_else(|| table.get("name")))
-                            .and_then(|path| path.as_str())
-                            .unwrap();
-                        bin_a_path.cmp(bin_b_path)
-                    });
-                }
-
-                let relative_path =
-                    pathdiff::diff_paths(&absolute_path, base_path).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Failed to compute relative path of manifest {:?}",
-                            &absolute_path
-                        )
-                    })?;
-                manifests.push(ParsedManifest {
-                    relative_path,
-                    contents: intermediate,
-                });
-            }
-            Err(e) => match handle_walk_error(e) {
-                ErrorStrategy::Ignore => {}
-                ErrorStrategy::Crash(e) => {
-                    return Err(e.into());
-                }
-            },
+        // Specifically, toml gives no guarantees to the ordering of the auto binaries
+        // in its results. We will manually sort these to ensure that the output
+        // manifest will match.
+        let bins = intermediate
+            .get_mut("bin")
+            .and_then(|bins| bins.as_array_mut());
+        if let Some(bins) = bins {
+            bins.sort_by(|bin_a, bin_b| {
+                let bin_a_path = bin_a
+                    .as_table()
+                    .and_then(|table| table.get("path").or_else(|| table.get("name")))
+                    .and_then(|path| path.as_str())
+                    .unwrap();
+                let bin_b_path = bin_b
+                    .as_table()
+                    .and_then(|table| table.get("path").or_else(|| table.get("name")))
+                    .and_then(|path| path.as_str())
+                    .unwrap();
+                bin_a_path.cmp(bin_b_path)
+            });
         }
+
+        let relative_path = pathdiff::diff_paths(&absolute_path, base_path).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Failed to compute relative path of manifest {:?}",
+                &absolute_path
+            )
+        })?;
+        manifests.push(ParsedManifest {
+            relative_path,
+            contents: intermediate,
+        });
     }
+
     Ok(manifests)
 }
 
@@ -134,25 +110,4 @@ pub(super) fn lockfile<P: AsRef<Path>>(
             Ok(None)
         }
     }
-}
-
-/// What should we should when we encounter an issue while walking the current directory?
-///
-/// If `ErrorStrategy::Ignore`, just skip the file/directory and keep going.
-/// If `ErrorStrategy::Crash`, stop exploring and return an error to the caller.
-enum ErrorStrategy {
-    Ignore,
-    Crash(WalkError),
-}
-
-/// Ignore directory/files for which we don't have enough permissions to perform our scan.
-#[must_use]
-fn handle_walk_error(e: WalkError) -> ErrorStrategy {
-    if let Some(inner) = e.io_error() {
-        if std::io::ErrorKind::PermissionDenied == inner.kind() {
-            log::warn!("Missing permission to read entry: {}\nSkipping.", inner);
-            return ErrorStrategy::Ignore;
-        }
-    }
-    ErrorStrategy::Crash(e)
 }

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -1014,6 +1014,50 @@ anyhow = { workspace = true }
     );
 }
 
+#[test]
+pub fn workspace_glob_members() {
+    // Arrange
+    let project = CargoWorkspace::new()
+        .manifest(
+            ".",
+            r#"
+[workspace]
+members = ["crates/*"]
+    "#,
+        )
+        .bin_package(
+            "crates/project_a",
+            r#"
+[package]
+name = "project_a"
+version = "0.0.1"
+    "#,
+        )
+        .lib_package(
+            "crates/project_b",
+            r#"
+[package]
+name = "project_b"
+version = "0.0.1"
+    "#,
+        )
+        .lib_package(
+            "crates-unused/project_c",
+            r#"
+[package]
+name = "project_c"
+version = "0.0.1"
+    "#,
+        )
+        .build();
+
+    // Act
+    let skeleton = Skeleton::derive(project.path(), None).unwrap();
+
+    // Assert
+    assert_eq!(skeleton.manifests.len(), 3);
+}
+
 fn check(actual: &str, expect: Expect) {
     let actual = actual.to_string();
     expect.assert_eq(&actual);

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -503,22 +503,23 @@ version = "0.0.1"
 #[test]
 pub fn workspace_version_lock() {
     // Arrange
+    // project-a is named with a dash to test that such unnormalized name can be handled.
     let project = CargoWorkspace::new()
         .manifest(
             ".",
             r#"
 [workspace]
 members = [
-    "src/project_a",
+    "src/project-a",
     "src/project_b",
 ]
 "#,
         )
         .bin_package(
-            "src/project_a",
+            "src/project-a",
             r#"
 [package]
-name = "project_a"
+name = "project-a"
 version = "1.2.3"
 edition = "2018"
 
@@ -543,7 +544,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 either = { version = "=1.8.1" }
-project_a = { version = "1.2.3", path = "../project_a" }   
+project-a = { version = "1.2.3", path = "../project-a" }   
 "#,
         )
         .file(
@@ -560,7 +561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
-name = "project_a"
+name = "project-a"
 version = "1.2.3"
 dependencies = [
  "either",
@@ -589,14 +590,14 @@ dependencies = [
     assert!(!lock_file.contains(
         r#"
 [[package]]
-name = "project_a"
+name = "project-a"
 version = "1.2.3"
 "#
     ));
     assert!(lock_file.contains(
         r#"
 [[package]]
-name = "project_a"
+name = "project-a"
 version = "0.0.1"
 "#
     ));
@@ -627,7 +628,7 @@ version = "1.8.1"
         &first.contents,
         expect_test::expect![[r#"
         [workspace]
-        members = ["src/project_a", "src/project_b"]
+        members = ["src/project-a", "src/project_b"]
     "#]],
     );
     let second = skeleton.manifests[1].clone();
@@ -651,7 +652,7 @@ version = "1.8.1"
             required-features = []
 
             [package]
-            name = "project_a"
+            name = "project-a"
             edition = "2018"
             version = "0.0.1"
             autobins = true
@@ -684,9 +685,9 @@ version = "1.8.1"
             [dependencies.either]
             version = "=1.8.1"
 
-            [dependencies.project_a]
+            [dependencies.project-a]
             version = "0.0.1"
-            path = "../project_a"
+            path = "../project-a"
 
             [lib]
             test = true


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/LukeMathWalker/cargo-chef/issues/152

*Description of changes:*
This PR adds basic usage of `cargo metadata`, which is not yet used to extract targets, but currently only to find workspace packages. This, adds built-in support for:
1) Ignoring vendored dependencies
2) Ignoring packages that are not part of the root workspace
3) Workspaces with packages specified using glob paths
4) Possibly also some other issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.