### PR TITLE
Fix tests on OSX after introduction of "cargo metadata"

### DIFF
--- a/tests/recipe.rs
+++ b/tests/recipe.rs
@@ -14,7 +14,7 @@ fn quick_recipe(content: &str) -> Recipe {
         bin_dir.child(filename).touch().unwrap();
         test_dir.child(filename).touch().unwrap();
     }
-    Recipe::prepare(recipe_directory.path().into(), None).unwrap()
+    Recipe::prepare(recipe_directory.path().canonicalize().unwrap(), None).unwrap()
 }
 
 #[test]

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -1122,7 +1122,7 @@ struct BuiltWorkspace {
     directory: TempDir,
 }
 impl BuiltWorkspace {
-    fn path(&self) -> &Path {
-        self.directory.path()
+    fn path(&self) -> PathBuf {
+        self.directory.canonicalize().unwrap()
     }
 }


### PR DESCRIPTION
A few tests started failing on OSX after https://github.com/LukeMathWalker/cargo-chef/commit/3a1236c980244ebe9799956c16c732a511bde6d3

> ---- version stdout ----
> thread 'version' panicked at 'called `Result::unwrap()` on an `Err` value: failed to create directory `/var/folders/yh/kzjp2v3s02v2g69v0cm8f4x40000gn/T/.tmpEnxbkt/../../../../../../private/var/folders/yh/kzjp2v3s02v2g69v0cm8f4x40000gn/T/.tmpeW4tEa`


OSX symlinks '/var' to '/private/var' - the paths created by TempDir start with '/var' but when read back via `cargo metadata` start with '/private/var'. 

This PR canonicalizes to ensure relative directory calculations work as expected on OSX.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
