### PR TITLE
We should keep all manifests, even if they are not mentioned in the list of workspace members

### DIFF
--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -357,16 +357,4 @@ fn ignore_all_members_except(manifests: &mut Vec<ParsedManifest>, member: String
     {
         *members = toml::Value::Array(vec![toml::Value::String(member.clone())]);
     }
-
-    // Keep only manifest(s) with package name equal to `member`
-    manifests.retain(|manifest| {
-        let package_name = manifest
-            .contents
-            .as_table()
-            .and_then(|t| t.get("package"))
-            .and_then(|t| t.as_table())
-            .and_then(|t| t.get("name"))
-            .and_then(|t| t.as_str());
-        package_name.is_none() || package_name == Some(&member)
-    });
 }

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -346,7 +346,7 @@ fn extract_cargo_metadata(path: &Path) -> Result<cargo_metadata::Metadata, anyho
 
 /// If the top-level `Cargo.toml` has a `members` field, replace it with
 /// a list consisting of just the specified member.
-fn ignore_all_members_except(manifests: &mut Vec<ParsedManifest>, member: String) {
+fn ignore_all_members_except(manifests: &mut [ParsedManifest], member: String) {
     let workspace_toml = manifests
         .iter_mut()
         .find(|manifest| manifest.relative_path == std::path::PathBuf::from("Cargo.toml"));
@@ -355,6 +355,6 @@ fn ignore_all_members_except(manifests: &mut Vec<ParsedManifest>, member: String
         .and_then(|toml| toml.contents.get_mut("workspace"))
         .and_then(|workspace| workspace.get_mut("members"))
     {
-        *members = toml::Value::Array(vec![toml::Value::String(member.clone())]);
+        *members = toml::Value::Array(vec![toml::Value::String(member)]);
     }
 }

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -823,18 +823,17 @@ edition = "2018"
     // Act
     let skeleton = Skeleton::derive(project.path(), "backend".to_string().into()).unwrap();
 
-    let gold = r#"[workspace]
-members = ["backend"]
-"#;
-
     // Assert:
-    // - that "ci" is not in `skeleton`'s manifests
+    // - that "ci" is *still* in the list of `skeleton`'s manifests
     assert!(skeleton
         .manifests
         .iter()
-        .all(|manifest| !manifest.contents.contains("ci")));
+        .any(|manifest| !manifest.contents.contains("ci")));
 
-    // - that the root manifest matches the file contents
+    // - that the list of members has been cut down to "backend", as expected
+    let gold = r#"[workspace]
+members = ["backend"]
+"#;
     assert!(
         skeleton
             .manifests


### PR DESCRIPTION
…since the binary target might depend on them via a path dependency.

We could be more surgical and keep exclusively the ones that are in the binary's transitive dependency closure, but we'll leave that for a future PR.