### PR TITLE
Masking should take into account package renames.

### DIFF
--- a/src/skeleton/version_masking.rs
+++ b/src/skeleton/version_masking.rs
@@ -75,7 +75,7 @@ fn mask_local_dependency_versions(
                         let mut must_mark_version = false;
 
                         if let Some(package_name) = dependency.get("package") {
-                            // We are dealing with a renamed package, so we check the name of the 
+                            // We are dealing with a renamed package, so we check the name of the
                             // "source" package.
                             if local_package_names.contains(package_name) {
                                 must_mark_version = true;

--- a/src/skeleton/version_masking.rs
+++ b/src/skeleton/version_masking.rs
@@ -70,10 +70,26 @@ fn mask_local_dependency_versions(
     fn _mask(local_package_names: &[toml::Value], toml_value: &mut toml::Value) {
         for dependency_key in ["dependencies", "dev-dependencies", "build-dependencies"] {
             if let Some(dependencies) = toml_value.get_mut(dependency_key) {
-                for local_package in local_package_names.iter() {
-                    if let toml::Value::String(local_package) = local_package {
-                        if let Some(local_dependency) = dependencies.get_mut(local_package) {
-                            if let Some(version) = local_dependency.get_mut("version") {
+                if let Some(dependencies) = dependencies.as_table_mut() {
+                    for (key, dependency) in dependencies {
+                        let mut must_mark_version = false;
+
+                        if let Some(package_name) = dependency.get("package") {
+                            // We are dealing with a renamed package, so we check the name of the 
+                            // "source" package.
+                            if local_package_names.contains(package_name) {
+                                must_mark_version = true;
+                            }
+                        } else {
+                            // The package has not been renamed, so we check the name of the
+                            // key in the dependencies table.
+                            if local_package_names.contains(&toml::Value::String(key.to_string())) {
+                                must_mark_version = true;
+                            }
+                        }
+
+                        if must_mark_version {
+                            if let Some(version) = dependency.get_mut("version") {
                                 *version = toml::Value::String(CONST_VERSION.to_string());
                             }
                         }

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use assert_fs::prelude::*;
 use assert_fs::TempDir;
 use chef::Skeleton;
-use expect_test::{Expect, expect};
+use expect_test::{expect, Expect};
 use predicates::prelude::*;
 
 #[test]
@@ -1095,7 +1095,9 @@ version = "0.2.1"
     // Act
     let skeleton = Skeleton::derive(project.path(), None).unwrap();
 
-    check(&skeleton.manifests[1].contents, expect![[r#"
+    check(
+        &skeleton.manifests[1].contents,
+        expect![[r#"
         bin = []
         bench = []
         test = []
@@ -1126,7 +1128,8 @@ version = "0.2.1"
         harness = true
         required-features = []
         crate-type = ["rlib"]
-    "#]]);
+    "#]],
+    );
 }
 
 fn check(actual: &str, expect: Expect) {


### PR DESCRIPTION
Our current implementation is a bit naive and doesn't account for package renames of local dependencies.
This PR fixes it.
