### PR TITLE
fix: Run `cargo metadata` with no-deps flag

### DIFF
--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -340,6 +340,7 @@ fn serialize_manifests(manifests: Vec<ParsedManifest>) -> Result<Vec<Manifest>, 
 fn extract_cargo_metadata(path: &Path) -> Result<cargo_metadata::Metadata, anyhow::Error> {
     let mut cmd = cargo_metadata::MetadataCommand::new();
     cmd.current_dir(path);
+    cmd.no_deps();
 
     cmd.exec().context("Cannot extract Cargo metadata")
 }


### PR DESCRIPTION
This change restores the old behaviour of ``cargo chef prepare`` which would finish quickly and not need Git credentials for private repos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
