### PR TITLE
Use `cargo metadata` to resolve targets

### DIFF
--- a/src/skeleton/target.rs
+++ b/src/skeleton/target.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum TargetKind {
     Lib { is_proc_macro: bool },
     Bin,
@@ -10,7 +10,7 @@ pub enum TargetKind {
     BuildScript,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Target {
     pub(crate) path: PathBuf,
     pub(crate) kind: TargetKind,

--- a/src/skeleton/target.rs
+++ b/src/skeleton/target.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum TargetKind {
+    Lib { is_proc_macro: bool },
+    Bin,
+    Test,
+    Bench,
+    Example,
+    BuildScript,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Target {
+    pub(crate) path: PathBuf,
+    pub(crate) kind: TargetKind,
+    pub(crate) name: String,
+}

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -280,6 +280,39 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[test]
+pub fn tests_no_harness() {
+    // Arrange
+    let project = CargoWorkspace::new()
+        .lib_package(
+            ".",
+            r#"
+[package]
+name = "test-dummy"
+version = "0.1.0"
+edition = "2018"
+
+[[test]]
+name = "foo"
+harness = false
+"#,
+        )
+        .touch("tests/foo.rs")
+        .build();
+
+    // Act
+    let skeleton = Skeleton::derive(project.path(), None).unwrap();
+    let cook_directory = TempDir::new().unwrap();
+    skeleton
+        .build_minimum_project(cook_directory.path(), false)
+        .unwrap();
+
+    cook_directory
+        .child("tests")
+        .child("foo.rs")
+        .assert("fn main() {}");
+}
+
+#[test]
 pub fn examples() {
     // Arrange
     let project = CargoWorkspace::new()


### PR DESCRIPTION
This should help generate the correct entrypoint file paths, instead of guessing them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.