### PR TITLE
Solve CI warnings replacing outdated actions

### DIFF
--- a/.github/workflows/audit-on-push.yml
+++ b/.github/workflows/audit-on-push.yml
@@ -8,7 +8,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
       -
         id: set-matrix
         run: |
-          echo -n '::set-output name=matrix::[' \
+          (echo -n 'matrix=[' \
           && curl --silent https://raw.githubusercontent.com/docker-library/official-images/master/library/rust \
             | grep -E Tags: \
             | cut -d ' ' -f 2- \
@@ -29,7 +29,7 @@ jobs:
             | sed 's/\(.*\)/"\1",/g' \
             | tr '\n' ' ' \
             | sed '$ s/..$//' \
-          && echo ']'
+          && echo ']') >> "$GITHUB_OUTPUT"
   build_and_push:
     name: Build and push
     needs: [rust_image_tag_matrix]
@@ -41,16 +41,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -61,14 +61,14 @@ jobs:
         run: |-
           git fetch --tags
           VER=$(git tag --sort="-v:refname" | head -n 1 | cut -d"v" -f2)
-          echo ::set-output name=result::$VER
+          echo "result=$VER" >> "$GITHUB_OUTPUT"
       -
         # Check if version matches ^\d+\.\d+\.\d+$
         name: Determine if release version
         id: is_release_version
         run: |
           if [[ ${{ steps.package_version.outputs.result }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=result::true
+            echo "result=true" >> "$GITHUB_OUTPUT"
           fi
       -
         name: Determine if duplicated
@@ -79,9 +79,9 @@ jobs:
 
           if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $CHEF_IMAGE >/dev/null; then
             echo "There is already a pushed image with ${CHEF_IMAGE_TAG} as tag. Skipping."
-            echo ::set-output name=result::true
+            echo "result=true" >> "$GITHUB_OUTPUT"
           else
-            echo ::set-output name=result::false
+            echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       -
         name: Build and push without `latest` tag

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -2,68 +2,44 @@ name: Rust
 
 on: [push, pull_request]
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+          components: clippy
+      - run: cargo clippy -- -D warnings
 
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -40,7 +40,10 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - name: Install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
         with:
-          args: '--ignore-tests'
+          tool: cargo-tarpaulin
+          checksum: true
+      - name: Run cargo-tarpaulin
+        run: cargo tarpaulin --ignore-tests

--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -8,7 +8,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: taiki-e/create-gh-release-action@v1
         with:
           branch: main
@@ -32,7 +32,7 @@ jobs:
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cargo-chef

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -6,7 +6,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Issue #, if available**

Try to remove noisy warnings inside github actions

**Description of changes**

Principally by bumping to new tag version (e.g.
`action/checkout`). But for unmaintained actions the swap
with a fork or something similar, is the only solution:
* [`action-rs/toolchain`](https://github.com/actions-rs/toolchain/issues/216) -> [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* [`action-rs/audit-check`](https://github.com/actions-rs/audit-check/issues/227) -> [`rustsec/audit-check`](https://github.com/rustsec/audit-check)

Two consequences of using `dtolnay/rust-toolchain` are:
* no more needed `CARGO_TERM_COLOR=always` already set by
the action
* use directly cargo commands in run steps

I also change [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) `::set-output` commands

A question to complete the PR:
How about `actions-rs/tarpauli` step? It was responsible for
the failure of general "Rust" workflow before the fork. It's
also unmaintained as all `action-rs/*`. A possible
replacement can be found, but I don't understand if it's still
used or not



*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
