### PR TITLE
Best practies for github actions: permissions and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"

--- a/.github/workflows/audit-on-push.yml
+++ b/.github/workflows/audit-on-push.yml
@@ -4,6 +4,11 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+
+permissions:
+  issues: write
+  checks: write
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '42 7 * * *' # run at 7:42 UTC (morning) every day
 
+permissions:
+  contents: read
+
 env:
   RUST_IMAGE_TAG: latest
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -2,6 +2,9 @@ name: Rust
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -2,6 +2,11 @@ name: Security audit
 on:
   schedule:
     - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  checks: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Related:** #221

**Description of changes:**

Explicitly set permissions required inside github actions

For **dependabot** what you'd prefer for `schedule` interval?
And for the preference you expressed:
> raise PRs unless there is a semver-breaking version bump

I think the closest behavior can be ignoring semver patch release for all actions,
instead minor, major usually can contain some breaking changes. Is it ok?

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
