### PR TITLE
Support Docker image for i386 and arm32v7 architectures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,13 +94,14 @@ jobs:
           CHEF_PACKAGE_VERSION=${{ steps.package_version.outputs.result }}
           CHEF_IMAGE=$DOCKER_REPO:$CHEF_PACKAGE_VERSION-rust-$RUST_IMAGE_TAG
           CHEF_IMAGE_LATEST=$DOCKER_REPO:latest-rust-$RUST_IMAGE_TAG
+          CHEF_IMAGE_PLATFORM="linux/amd64,linux/arm64$(if [[ "$RUST_IMAGE_TAG" != *alpine* ]]; then echo ",linux/386,linux/arm/v7"; fi)"
 
           docker buildx build \
             --tag $CHEF_IMAGE \
             --tag $CHEF_IMAGE_LATEST \
             --build-arg=BASE_IMAGE=rust:$RUST_IMAGE_TAG \
             --build-arg=CHEF_TAG=$CHEF_PACKAGE_VERSION \
-            --platform linux/amd64,linux/arm64 \
+            --platform $CHEF_IMAGE_PLATFORM \
             --push \
             ./docker
       -
@@ -119,6 +120,6 @@ jobs:
             --tag $DOCKER_REPO:latest \
             --build-arg=BASE_IMAGE=rust:$RUST_IMAGE_TAG \
             --build-arg=CHEF_TAG=$CHEF_PACKAGE_VERSION \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64,linux/arm64,linux/386,linux/arm/v7 \
             --push \
             ./docker


### PR DESCRIPTION
*Issue #, if available:* #182 

*Description of changes:* Add 386 and arm/v7 to Docker image build platform.

Official rust docker image is depends on rustup. And rustup doesn't support i386 and arm/v7 for musl(alpine) target.
This PR adds build target 'i386' and 'arm/v7' on non-alpine target. According to https://github.com/LukeMathWalker/cargo-chef/issues/182#issuecomment-1616805177, this should be ok.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
