### PR TITLE
Add `--bins` and allow `--bin` to be called multiple times

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,10 +138,9 @@ pub struct Cook {
     /// Cook using `#[no_std]` configuration  (does not affect `proc-macro` crates)
     #[clap(long)]
     no_std: bool,
-    /// When --bin is specified, `cargo-chef` will ignore all members of the workspace
-    /// that are not necessary to successfully compile the specific binary.
+    /// Build only the specified binary. This can be specified with multiple binaries.
     #[clap(long)]
-    bin: Option<String>,
+    bin: Option<Vec<String>>,
     /// Build all binaries and ignore everything else.
     #[clap(long)]
     bins: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,9 @@ pub struct Cook {
     /// that are not necessary to successfully compile the specific binary.
     #[clap(long)]
     bin: Option<String>,
+    /// Build all binaries and ignore everything else.
+    #[clap(long)]
+    bins: bool,
     /// Run `cargo zigbuild` instead of `cargo build`. You need to install
     /// the `cargo-zigbuild` crate and the Zig compiler toolchain separately
     #[clap(long)]
@@ -185,6 +188,7 @@ fn _main() -> Result<(), anyhow::Error> {
             no_std,
             bin,
             zigbuild,
+            bins,
         }) => {
             if atty::is(atty::Stream::Stdout) {
                 eprintln!("WARNING stdout appears to be a terminal.");
@@ -282,6 +286,7 @@ fn _main() -> Result<(), anyhow::Error> {
                     locked,
                     frozen,
                     verbose,
+                    bins,
                 })
                 .context("Failed to cook recipe.")?;
         }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -44,6 +44,7 @@ pub struct CookArgs {
     pub timings: bool,
     pub no_std: bool,
     pub bin: Option<String>,
+    pub bins: bool,
 }
 
 impl Recipe {
@@ -109,6 +110,7 @@ fn build_dependencies(args: &CookArgs) {
         timings,
         bin,
         no_std: _no_std,
+        bins,
     } = args;
     let cargo_path = std::env::var("CARGO").expect("The `CARGO` environment variable was not set. This is unexpected: it should always be provided by `cargo` when invoking a custom sub-command, allowing `cargo-chef` to correctly detect which toolchain should be used. Please file a bug.");
     let mut command = Command::new(cargo_path);
@@ -186,6 +188,9 @@ fn build_dependencies(args: &CookArgs) {
     }
     if *timings {
         command_with_args.arg("--timings");
+    }
+    if *bins {
+        command_with_args.arg("--bins");
     }
 
     execute_command(command_with_args);

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -43,7 +43,7 @@ pub struct CookArgs {
     pub verbose: bool,
     pub timings: bool,
     pub no_std: bool,
-    pub bin: Option<String>,
+    pub bin: Option<Vec<String>>,
     pub bins: bool,
 }
 
@@ -169,7 +169,9 @@ fn build_dependencies(args: &CookArgs) {
         }
     }
     if let Some(binary_target) = bin {
-        command_with_args.arg("--bin").arg(binary_target);
+        for binary_target in binary_target {
+            command_with_args.arg("--bin").arg(binary_target);
+        }
     }
     if *workspace {
         command_with_args.arg("--workspace");


### PR DESCRIPTION
*Issue #, if available:* #238 

*Description of changes:* Adds `--bins` which builds all binaries. The second commit makes it possible to call `--bin` multiple times like `--package`. This is to be closer in usage to other cargo commands such as cargo build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
