### PR TITLE
use the manifest path instead of just the member name when using `prepare --bin`

### DIFF
--- a/src/skeleton/read.rs
+++ b/src/skeleton/read.rs
@@ -39,7 +39,7 @@ pub(super) fn config<P: AsRef<Path>>(base_path: &P) -> Result<Option<String>, an
 
 pub(super) fn manifests<P: AsRef<Path>>(
     base_path: &P,
-    metadata: Metadata,
+    metadata: &Metadata,
 ) -> Result<Vec<ParsedManifest>, anyhow::Error> {
     let mut packages: BTreeMap<PathBuf, BTreeSet<Target>> = metadata
         .workspace_packages()

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -1672,6 +1672,9 @@ uuid = { version = "=0.8.0", features = ["v4"] }
 
     let project_f = Skeleton::derive(&path, Some("project_f".into())).unwrap();
     assert_eq!(manifest_content_dirs(&project_f), vec!["project_f"]);
+
+    // TODO: If multiple binaries are valid in `cargo chef prepare`, then testing
+    // with multiple binaries is probably a good idea here!
 }
 
 struct BuiltWorkspace {

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -1517,6 +1517,163 @@ impl CargoWorkspace {
     }
 }
 
+/// See https://github.com/LukeMathWalker/cargo-chef/issues/232.
+#[test]
+pub fn workspace_bin_nonstandard_dirs() {
+    // Arrange
+    let project = CargoWorkspace::new()
+        .manifest(
+            ".",
+            r#"
+[workspace]
+members = [
+    "crates/client/project_a",
+    "crates/client/project_b",
+    "crates/server/*",
+    "vendored/project_e",
+    "project_f",
+]        
+"#,
+        )
+        .bin_package(
+            "crates/client/project_a",
+            r#"
+[package]
+name = "project_a"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+uuid = { version = "=0.8.0", features = ["v4"] }
+"#,
+        )
+        .bin_package(
+            "crates/client/project_b",
+            r#"
+[package]
+name = "project_b"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+uuid = { version = "=0.8.0", features = ["v4"] }
+"#,
+        )
+        .bin_package(
+            "crates/server/project_c",
+            r#"
+[package]
+name = "project_c"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+uuid = { version = "=0.8.0", features = ["v4"] }
+"#,
+        )
+        .bin_package(
+            "crates/server/project_d",
+            r#"
+[package]
+name = "project_d"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+uuid = { version = "=0.8.0", features = ["v4"] }
+"#,
+        )
+        .bin_package(
+            "vendored/project_e",
+            r#"
+[package]
+name = "project_e"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+uuid = { version = "=0.8.0", features = ["v4"] }
+"#,
+        )
+        .bin_package(
+            "project_f",
+            r#"
+[package]
+name = "project_f"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+uuid = { version = "=0.8.0", features = ["v4"] }
+"#,
+        )
+        .build();
+
+    fn manifest_content_dirs(skeleton: &Skeleton) -> Vec<String> {
+        // This is really ugly... sorry.
+        skeleton
+            .manifests
+            .first()
+            .unwrap()
+            .contents
+            .split("=")
+            .last()
+            .unwrap()
+            .replace(['[', ']', '"'], "")
+            .trim()
+            .split(",")
+            .map(|w| w.trim().to_string())
+            .collect()
+    }
+
+    // Act
+    let path = project.path();
+    let all = Skeleton::derive(&path, None).unwrap();
+    assert_eq!(
+        manifest_content_dirs(&all),
+        vec![
+            "crates/client/project_a",
+            "crates/client/project_b",
+            "crates/server/*",
+            "vendored/project_e",
+            "project_f"
+        ]
+    );
+
+    let project_a = Skeleton::derive(&path, Some("project_a".into())).unwrap();
+    assert_eq!(
+        manifest_content_dirs(&project_a),
+        vec!["crates/client/project_a"]
+    );
+
+    let project_b = Skeleton::derive(&path, Some("project_b".into())).unwrap();
+    assert_eq!(
+        manifest_content_dirs(&project_b),
+        vec!["crates/client/project_b"]
+    );
+
+    let project_c = Skeleton::derive(&path, Some("project_c".into())).unwrap();
+    assert_eq!(
+        manifest_content_dirs(&project_c),
+        vec!["crates/server/project_c"]
+    );
+
+    let project_d = Skeleton::derive(&path, Some("project_d".into())).unwrap();
+    assert_eq!(
+        manifest_content_dirs(&project_d),
+        vec!["crates/server/project_d"]
+    );
+
+    let project_e = Skeleton::derive(&path, Some("project_e".into())).unwrap();
+    assert_eq!(
+        manifest_content_dirs(&project_e),
+        vec!["vendored/project_e"]
+    );
+
+    let project_f = Skeleton::derive(&path, Some("project_f".into())).unwrap();
+    assert_eq!(manifest_content_dirs(&project_f), vec!["project_f"]);
+}
+
 struct BuiltWorkspace {
     directory: TempDir,
 }

--- a/tests/skeletons.rs
+++ b/tests/skeletons.rs
@@ -1616,12 +1616,12 @@ uuid = { version = "=0.8.0", features = ["v4"] }
             .first()
             .unwrap()
             .contents
-            .split("=")
+            .split('=')
             .last()
             .unwrap()
             .replace(['[', ']', '"'], "")
             .trim()
-            .split(",")
+            .split(',')
             .map(|w| w.trim().to_string())
             .collect()
     }


### PR DESCRIPTION
*Issue #, if available:*

Closes: #232 

*Description of changes:*

The current code assumes that when running `prepare` with `--bin`, that we can remove all members and just add one member that is equal to whatever we passed in `--bin`.

The problem with that is that if your packages aren't in the exact same root directory, then this will result in a recipe file that breaks once you try calling `cook` on it.

To fix this, this PR instead sets the sole member to the _path_ of the package, which (I think) can be found using in `cargo_metadata::Metadata`, grabbing the manifest path, and setting it to be relative to the workspace root + removing `Cargo.toml` from the path. I chose to do it this way rather than just matching + grabbing whatever's in the `members` array as I don't think that would work due to wildcards being valid.

This also adds a test emulating various package locations in a workspace and seeing if the path is correctly set. This previously failed, but now passes with these changes. All other previously-existing tests seem to pass, so I don't believe this should break things. That said, if people were using the workaround mentioned in #232, then I believe this will be a breaking change, so that'll probably have to be communicated.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
