### PR TITLE
chore: Replace atty crate with std::io::IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,17 +96,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,7 +140,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
- "atty",
  "cargo-manifest",
  "cargo_metadata",
  "clap",
@@ -407,15 +395,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
@@ -458,7 +437,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ name = "chef"
 path = "src/lib.rs"
 
 [dependencies]
-atty = "0.2.14"
 clap = { version = "4", features = ["cargo", "env", "derive"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::crate_version;
 use clap::Parser;
 use fs_err as fs;
 use std::collections::HashSet;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 /// Cache the dependencies of your Rust project.
@@ -189,7 +190,7 @@ fn _main() -> Result<(), anyhow::Error> {
             zigbuild,
             bins,
         }) => {
-            if atty::is(atty::Stream::Stdout) {
+            if std::io::stdout().is_terminal() {
                 eprintln!("WARNING stdout appears to be a terminal.");
                 eprintln!(
                     "cargo-chef is not meant to be run in an interactive environment \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replaces `atty` crate with `std::io::IsTerminal` trait.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
