### PR TITLE
Enable ppc64le builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,7 @@ jobs:
             --tag $CHEF_IMAGE_LATEST \
             --build-arg=BASE_IMAGE=rust:$RUST_IMAGE_TAG \
             --build-arg=CHEF_TAG=$CHEF_PACKAGE_VERSION \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64,linux/arm64,linux/ppc64le \
             --push \
             ./docker
       -
@@ -119,6 +119,6 @@ jobs:
             --tag $DOCKER_REPO:latest \
             --build-arg=BASE_IMAGE=rust:$RUST_IMAGE_TAG \
             --build-arg=CHEF_TAG=$CHEF_PACKAGE_VERSION \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64,linux/arm64,linux/ppc64le \
             --push \
             ./docker


### PR DESCRIPTION
This PR adds support to build cargo-chef for linux-based Power systems (ppc64le)