### PR TITLE
Upgrade libc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,9 +451,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"


### PR DESCRIPTION
While packaging this crate for Alpine Linux I've realized that locked dependencies haven't been upgraded for a while. In particular the current locked version of `libc` doesn't support loongarch64. This PR bumps it so that we can remove our fix downstream (https://gitlab.alpinelinux.org/alpine/aports/-/blob/a341ac413c530a2c4288486f2f16f1153d5c1f5e/testing/cargo-chef/APKBUILD#L26).