### PR TITLE
fix: Assign `CHEF_IMAGE_TAG` before it is used in `CHEF_IMAGE` env

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,8 +77,9 @@ jobs:
         name: Determine if duplicated
         id: is_duplicated
         run: |
-          CHEF_IMAGE=$DOCKER_REPO:$CHEF_IMAGE_TAG
+          CHEF_PACKAGE_VERSION=${{ steps.package_version.outputs.result }}
           CHEF_IMAGE_TAG=$CHEF_PACKAGE_VERSION-rust-$RUST_IMAGE_TAG
+          CHEF_IMAGE=$DOCKER_REPO:$CHEF_IMAGE_TAG
 
           if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $CHEF_IMAGE >/dev/null; then
             echo "There is already a pushed image with ${CHEF_IMAGE_TAG} as tag. Skipping."


### PR DESCRIPTION
I am not sure what had happened here...

In this commit: https://github.com/LukeMathWalker/cargo-chef/commit/9e017baaa49ab80bdf3cdaf2e54978322df48fa7, the is_duplicated step appears to be broken.

You can observe it for example here: https://github.com/LukeMathWalker/cargo-chef/actions/runs/15361613141/job/43229423187
```
Run CHEF_IMAGE=$DOCKER_REPO:$CHEF_IMAGE_TAG
  CHEF_IMAGE=$DOCKER_REPO:$CHEF_IMAGE_TAG
  CHEF_IMAGE_TAG=$CHEF_PACKAGE_VERSION-rust-$RUST_IMAGE_TAG
  
  if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $CHEF_IMAGE >/dev/null; then
    echo "There is already a pushed image with ${CHEF_IMAGE_TAG} as tag. Skipping."
    echo "result=true" >> "$GITHUB_OUTPUT"
  else
    echo "result=false" >> "$GITHUB_OUTPUT"
  fi
  shell: /usr/bin/bash -e {0}
  env:
    RUST_IMAGE_TAG: latest
    DOCKERHUB_USERNAME: ***
    DOCKERHUB_TOKEN: ***
    DOCKER_REPO: ***/cargo-chef
invalid reference format
```

I believe this causes every release to be pushed to the Docker registry, even when no changes occurred.