### PR TITLE
Set `RUST_IMAGE_TAG` from matrix when determining duplicate

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,6 +77,7 @@ jobs:
         name: Determine if duplicated
         id: is_duplicated
         run: |
+          RUST_IMAGE_TAG=${{ matrix.rust_image_tag }}
           CHEF_PACKAGE_VERSION=${{ steps.package_version.outputs.result }}
           CHEF_IMAGE_TAG=$CHEF_PACKAGE_VERSION-rust-$RUST_IMAGE_TAG
           CHEF_IMAGE=$DOCKER_REPO:$CHEF_IMAGE_TAG


### PR DESCRIPTION
Current check for `is_duplicate` always produces false with `There is already a pushed image with 0.1.71-rust-latest as tag. Skipping.`, even for a matrix case with non-latest tag:
https://github.com/LukeMathWalker/cargo-chef/actions/runs/15966985726/job/45029376177

As I understand, the top-level env definition of `RUST_IMAGE_TAG` is used, because it is not set in the `is_duplicate` step