### PR TITLE
ci: add release for aarch64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -33,6 +33,8 @@ jobs:
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
fixes #316 