### PR TITLE
skeleton: mod fix Clippy warning on comparison of path with non-path

### DIFF
--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -331,7 +331,7 @@ fn ignore_all_members_except(
 ) {
     let workspace_toml = manifests
         .iter_mut()
-        .find(|manifest| manifest.relative_path == std::path::PathBuf::from("Cargo.toml"));
+        .find(|manifest| manifest.relative_path == Path::new("Cargo.toml"));
 
     if let Some(workspace) = workspace_toml.and_then(|toml| toml.contents.get_mut("workspace")) {
         if let Some(members) = workspace.get_mut("members") {


### PR DESCRIPTION
Compare path object with path object to resolve Clippy warning.

Error details before the fix:

> error: this creates an owned instance just for comparison
>    --> src/skeleton/mod.rs:334:52
>     |
> 334 |         .find(|manifest| manifest.relative_path == std::path::PathBuf::from("Cargo.toml"));
>     |                          --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>     |                          |
>     |                          help: try: `manifest.relative_path == "Cargo.toml"`
>     |
>     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#cmp_owned
>     = note: `-D clippy::cmp-owned` implied by `-D warnings`
>     = help: to override `-D warnings` add `#[allow(clippy::cmp_owned)]`
> 

Note: I have no idea about Rust language or if this correct, this does make the warning go away but I am not sure if this correctly compares the path content or if it is doing something unintended like comparing objects, please review.