### PR TITLE
chore: release v0.1.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.75](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.74...v0.1.75) - 2026-02-28
+
+### Added
+
+- Support the --jobs flags.
+
+### Other
+
+- Disable semver check. We version based on the CLI interface, not the library one
+- Bump rustsec/audit-check from 1.4.1 to 2.0.0 ([#278](https://github.com/LukeMathWalker/cargo-chef/pull/278))
+- Use a PAT to allow release-plz's job to trigger other workflows
+
 ## [0.1.74](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.73...v0.1.74) - 2026-02-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-chef"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chef"
-version = "0.1.74"
+version = "0.1.75"
 authors = ["Luca Palmieri <lpalmieri@truelayer.com>"]
 edition = "2018"
 description = "A cargo sub-command to build project dependencies for optimal Docker layer caching."


### PR DESCRIPTION



## 🤖 New release

* `cargo-chef`: 0.1.74 -> 0.1.75

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.75](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.74...v0.1.75) - 2026-02-28

### Added

- Support the --jobs flags.

### Other

- Disable semver check. We version based on the CLI interface, not the library one
- Bump rustsec/audit-check from 1.4.1 to 2.0.0 ([#278](https://github.com/LukeMathWalker/cargo-chef/pull/278))
- Use a PAT to allow release-plz's job to trigger other workflows
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).