### PR TITLE
chore: release v0.1.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.76](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.75...v0.1.76) - 2026-03-03
+
+### Added
+
+- Minimize generated recipe to increase cache hit ratio when `cargo chef prepare` is invoked with a `--bin` option
+- Publish a prebuilt `cargo-chef` Docker image for every upstream Rust tag. 
+- Broaden the set of supported architectures for Docker images to include `i386` and `arm32v7`
+
+### Other
+
+- Upgrade to latest versions of all dependencies
+- Allow cargo-chef to fetch dependencies in `cargo chef prepare`, if either `--bin` was specified or
+  the lockfile is missing.
+
 ## [0.1.75](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.74...v0.1.75) - 2026-02-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-chef"
-version = "0.1.75"
+version = "0.1.76"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chef"
-version = "0.1.75"
+version = "0.1.76"
 authors = ["Luca Palmieri <lpalmieri@truelayer.com>"]
 edition = "2018"
 description = "A cargo sub-command to build project dependencies for optimal Docker layer caching."


### PR DESCRIPTION



## 🤖 New release

* `cargo-chef`: 0.1.75 -> 0.1.76

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.76](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.75...v0.1.76) - 2026-03-03

### Added

- Minimize recipe to increase cache hit ratio
- Publish a prebuilt cargo-chef image for every upstream rust tag. Broaden architecture support to include , and

### Other

- Upgrade to latest versions of dependencies
- Use HashSet rather than Vec for contains check
- Use 'cargo metadata --no-deps' when prepare wasn't given a --bin option
- Allow cargo-chef to fetch dependencies when computing the package graph
- Don't use fetch to get tags
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).