### PR TITLE
chore: add OCI annotations

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,3 +7,6 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN ((cat /etc/os-release | grep ID | grep alpine) && apk add --no-cache musl-dev || true) \
     && cargo install cargo-chef --locked --version $CHEF_TAG \
     && rm -rf $CARGO_HOME/registry/
+
+LABEL org.opencontainers.image.source="https://github.com/LukeMathWalker/cargo-chef"
+LABEL org.opencontainers.image.description="Cache the dependencies of your Rust project and speed up your Docker builds"


### PR DESCRIPTION
This is useful to allow Dependabot to fetch Docker metadata: https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#docker

See the specification:
https://specs.opencontainers.org/image-spec/annotations/