### PR TITLE
chore: release v0.1.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.78](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.77...v0.1.78) - 2026-04-13
+
+### Added
+
+- toml v1.1 support
+
+### Other
+
+- add OCI annotations
+
 ## [0.1.77](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.76...v0.1.77) - 2026-03-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-chef"
-version = "0.1.77"
+version = "0.1.78"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chef"
-version = "0.1.77"
+version = "0.1.78"
 authors = ["Luca Palmieri <lpalmieri@truelayer.com>"]
 edition = "2018"
 description = "A cargo sub-command to build project dependencies for optimal Docker layer caching."


### PR DESCRIPTION



## 🤖 New release

* `cargo-chef`: 0.1.77 -> 0.1.78

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.78](https://github.com/LukeMathWalker/cargo-chef/compare/v0.1.77...v0.1.78) - 2026-04-13

### Added

- toml v1.1 support

### Other

- add OCI annotations
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).