### PR TITLE
Make sure that cargo picks up rust-toolchain.toml changes

### DIFF
--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -63,7 +63,7 @@ impl Recipe {
         if args.no_build {
             return Ok(());
         }
-        build_dependencies(&args);
+        build_dependencies(&args, self.skeleton.rust_toolchain_file.is_some());
         self.skeleton
             .remove_compiled_dummies(
                 current_directory,
@@ -95,7 +95,7 @@ pub enum AllFeatures {
     Disabled,
 }
 
-fn build_dependencies(args: &CookArgs) {
+fn build_dependencies(args: &CookArgs, restored_rust_toolchain_file: bool) {
     let CookArgs {
         profile,
         command: command_arg,
@@ -120,7 +120,16 @@ fn build_dependencies(args: &CookArgs) {
         no_build: _no_build,
         jobs,
     } = args;
-    let cargo_path = std::env::var("CARGO").expect("The `CARGO` environment variable was not set. This is unexpected: it should always be provided by `cargo` when invoking a custom sub-command, allowing `cargo-chef` to correctly detect which toolchain should be used. Please file a bug.");
+    let cargo_path = if restored_rust_toolchain_file {
+        // if we just restored a rust-toolchain.toml from the recipe, RUSTUP_TOOLCHAIN might
+        // point to the wrong thing
+        std::env::remove_var("RUSTUP_TOOLCHAIN");
+        // Simply invoking `cargo` from the path without RUSTUP_TOOLCHAIN set will make cargo
+        // pick up the right toolchain
+        "cargo".to_string()
+    } else {
+        std::env::var("CARGO").expect("The `CARGO` environment variable was not set. This is unexpected: it should always be provided by `cargo` when invoking a custom sub-command, allowing `cargo-chef` to correctly detect which toolchain should be used. Please file a bug.")
+    };
     let mut command = Command::new(cargo_path);
     let command_with_args = match command_arg {
         CommandArg::Build => command.arg("build"),


### PR DESCRIPTION
When cargo chef cook generates a rust-toolchain.toml file, this change ensures that the cargo build invocation picks up the the rust-toolchain.toml config by unsetting the RUSTUP_TOOLCHAIN environment variable.

Fixes #271