### PR TITLE
feat: build macOS release binaries

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program


### PR DESCRIPTION
## Summary

Add `aarch64-apple-darwin` and `x86_64-apple-darwin` to `dist-workspace.toml` so each release ships prebuilt macOS binaries alongside the Linux ones. `dist` already maps these targets to the appropriate GitHub-hosted runners (`macos-14` for arm64, `macos-15-intel` for x86_64), so no other changes are needed.

## Background

- The pre-`dist` release workflow (`publish_binaries.yml`, removed in #330 "Modernize publishing pipeline") published `x86_64-apple-darwin` via `taiki-e/upload-rust-binary-action`.
- The replacement `dist`-based pipeline only listed Linux targets, so since v0.1.74 every release has been Linux-only. I couldn't find any issue or PR discussion indicating macOS was intentionally dropped — looks like an oversight during the modernization.
- I checked open issues/PRs for explicit "no macOS" reasoning and didn't find any; the closest related thread is #356 (users hitting `cargo install` MSRV problems, who would benefit from prebuilt binaries).

## Asset naming / mise compatibility

`dist` produces `cargo-chef-aarch64-apple-darwin.tar.xz` and `cargo-chef-x86_64-apple-darwin.tar.xz` by default. The `mise` GitHub backend ([docs](https://mise.jdx.dev/dev-tools/backends/github.html)) recognizes the standard Rust target-triple substrings out of the box, so users will be able to do:

```
mise use ubi:LukeMathWalker/cargo-chef
```

…on macOS without any additional `asset_pattern` configuration. This matches the convention used by e.g. [kunobi-ninja/kache](https://github.com/kunobi-ninja/kache/releases).

## Verification

Locally regenerated CI with `dist generate` (no diff, since the matrix is computed at runtime from `dist-workspace.toml`) and confirmed via `dist plan`:

```
aarch64-apple-darwin  -> macos-14
x86_64-apple-darwin   -> macos-15-intel
aarch64-unknown-linux-gnu  -> ubuntu-22.04-arm
aarch64-unknown-linux-musl -> ubuntu-22.04-arm
x86_64-unknown-linux-gnu   -> ubuntu-22.04
x86_64-unknown-linux-musl  -> ubuntu-22.04
```

## Test plan

- [ ] CI green on this PR (the release workflow runs on `pull_request`, exercising the build matrix without publishing).
- [ ] On the next tagged release, confirm the GitHub Release contains `cargo-chef-aarch64-apple-darwin.tar.xz` and `cargo-chef-x86_64-apple-darwin.tar.xz` (plus their `.sha256` files).
- [ ] After release, verify `mise use ubi:LukeMathWalker/cargo-chef` resolves the right asset on an Apple Silicon and an Intel Mac.
